### PR TITLE
readable streams as file option

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -3,6 +3,7 @@ var querystring = require('querystring'),
     fs = require('fs'),
     p = require('path'),
     url = require('url');
+    stream = require('stream');
 
 
 var Modem = function(opts) {
@@ -14,7 +15,7 @@ var Modem = function(opts) {
 
 
 Modem.prototype.dial = function(options, callback) {
-  var opts, address, data;
+  var opts, address, data, datastream;
   var self = this;
 
   if (options.options) {
@@ -52,7 +53,11 @@ Modem.prototype.dial = function(options, callback) {
   }
 
   if(options.file) {
-    data = fs.readFileSync(p.resolve(options.file));
+    if (options.file instanceof stream.Readable) {
+      datastream = options.file
+    } else {
+      data = fs.readFileSync(p.resolve(options.file));
+    }
     optionsf.headers['Content-Type'] = 'application/tar';
   } else if(opts && options.method === 'POST') {
     data = JSON.stringify(opts);
@@ -100,7 +105,11 @@ Modem.prototype.dial = function(options, callback) {
   if(data) {
     req.write(data);
   }
-  req.end();
+  if (datastream) {
+    datastream.pipe(req);
+  } else {
+    req.end();
+  }
 };
 
 


### PR DESCRIPTION
It is now possible to pass a readable stream instead of a file name to `options.file`.

See also [issue 28 on dockerode](https://github.com/apocas/dockerode/issues/28).
