### PR TITLE
Put options listed in urlParams into the query string

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -41,6 +41,16 @@ Modem.prototype.dial = function(options, callback) {
     }
   }
 
+  if(options.urlParams) {
+    var query = {}
+    for (var i = 0; i < options.urlParams.length; i++) {
+      var key = options.urlParams[i];
+      query[key] = opts[key];
+      delete opts[key];
+    }
+    address += '?' + querystring.stringify(query);
+  }
+
   var optionsf = {
     path: address,
     method: options.method


### PR DESCRIPTION
This used to be included in the code in appersonlabs/docker.io, but it looks
it was dropped when pulling out the code as a module. It allows containers
to be named, since the 'name' parameter to /containers/create must be passed
in the query string.
