### PR TITLE
Adding module 'HttpDuplex' to support attach with stdin.

### DIFF
--- a/lib/http_duplex.js
+++ b/lib/http_duplex.js
@@ -1,0 +1,46 @@
+module.exports = HttpDuplex
+
+var util = require('util')
+  , stream = require('stream');
+
+if (process.version.match(/^\v0\.8/)) stream = require('readable-stream')
+
+util.inherits(HttpDuplex, stream.Duplex)
+
+function HttpDuplex(req, res, options) {
+  var self = this
+
+  if (! (self instanceof HttpDuplex)) return new HttpDuplex(req, res)
+
+  stream.Duplex.call(self, options)
+  self._output = null
+
+  self.connect(req, res)
+}
+
+HttpDuplex.prototype.connect = function (req, res) {
+  var self = this
+  self.req = req
+  self._output = res
+  self.emit('response', res)
+
+  res.on('data', function (c) {
+    if (!self.push(c)) self._output.pause()
+  })
+  res.on('end', function() {
+    self.push(null)
+  })
+}
+
+HttpDuplex.prototype._read = function (n) {
+  if (this._output) this._output.resume()
+}
+
+HttpDuplex.prototype._write = function (chunk, encoding, cb) {
+  this.req.write(chunk, encoding);
+  cb();
+}
+
+HttpDuplex.prototype.end = function (chunk, encoding, cb) {
+  return this.req.end(chunk, encoding, cb)
+}

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -3,8 +3,8 @@ var querystring = require('querystring'),
     fs = require('fs'),
     p = require('path'),
     url = require('url');
-    stream = require('stream');
-
+    stream = require('stream'),
+    HttpDuplex = require('./http_duplex');
 
 var Modem = function(opts) {
   this.socketPath = opts.socketPath;
@@ -79,7 +79,7 @@ Modem.prototype.dial = function(options, callback) {
 
   req.on('response', function(res) {
     if (options.isStream) {
-      self.buildPayload(null, options.isStream, options.statusCodes, res, null, callback);
+      self.buildPayload(null, options.isStream, options.statusCodes, options.openStdin, req, res, null, callback);
     } else {
       var chunks = '';
       res.on('data', function(chunk) {
@@ -93,13 +93,13 @@ Modem.prototype.dial = function(options, callback) {
         } catch(e) {
           json = chunks;
         }
-        self.buildPayload(null, options.isStream, options.statusCodes, res, json, callback);
+        self.buildPayload(null, options.isStream, options.statusCodes, false, req, res, json, callback);
       });
     }
   });
 
   req.on('error', function(error) {
-    self.buildPayload(error, options.isStream, options.statusCodes, {}, null, callback);
+    self.buildPayload(error, options.isStream, options.statusCodes, false, {}, {}, null, callback);
   });
 
   if(data) {
@@ -107,13 +107,12 @@ Modem.prototype.dial = function(options, callback) {
   }
   if (datastream) {
     datastream.pipe(req);
-  } else {
+  } else if (!options.openStdin) {
     req.end();
   }
 };
 
-
-Modem.prototype.buildPayload = function(err, isStream, statusCodes, res, json, cb) {
+Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, req, res, json, cb) {
   if (err) return cb(err, null);
 
   if (statusCodes[res.statusCode] !== true) {
@@ -122,7 +121,9 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, res, json, c
     );
     cb(msg, null);
   } else {
-    if (isStream) {
+    if (openStdin) {
+      cb(null, new HttpDuplex(req, res));
+    } else if (isStream) {
       cb(null, res);
     } else {
       cb(null, json);


### PR DESCRIPTION
With this you can attach a device to read the stream, thus allowing the use of stdin attach the container for example.

The reference project: https://github.com/isaacs/http-duplex-client
