### PR TITLE
Expose more meaningful errors

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -129,6 +129,9 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, r
     var msg = new Error(
       'HTTP code is ' + res.statusCode + ' which indicates error: ' + statusCodes[res.statusCode] + ' - ' + json
     );
+    msg.reason = statusCodes[res.statusCode];
+    msg.statusCode = res.statusCode;
+    msg.json = json;
     cb(msg, null);
   } else {
     if (openStdin) {


### PR DESCRIPTION
adds `reason`, `statusCode` and `json` to the error object

should fix #9 and https://github.com/apocas/dockerode/issues/40
