### PR TITLE
Correctly detect if a variable is a string

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -67,7 +67,7 @@ Modem.prototype.dial = function(options, callback) {
   }
 
   if(data) {
-    if(data instanceof String) {
+    if(typeof data === "string") {
       optionsf.headers['Content-Length'] = Buffer.byteLength(data);
     } else {
       optionsf.headers['Content-Length'] = data.length;


### PR DESCRIPTION
`instanceof` does not work with strings that are created as literals

``` javascript
"x" instanceof String
// false
typeof "x" === "string"
// true
```

(Note, it does work with strings created using the string constructor, but that's not common

``` javascript
new String("x") instanceof String
// true
```

)
