### PR TITLE
fixing stream detection

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -55,7 +55,11 @@ Modem.prototype.dial = function(options, callback) {
   }
 
   if(options.file) {
-    if (stream.Readable ? options.file instanceof stream.Readable : options.file instanceof stream && options.file.readable) {
+    var isStream = stream.Readable
+      ? (typeof options.file._readableState ==='object' && options.file.readable) || options.file instanceof stream.Readable 
+      : options.file instanceof stream && options.file.readable
+
+    if (isStream) {
       datastream = options.file;
     } else {
       data = fs.readFileSync(p.resolve(options.file));


### PR DESCRIPTION
- the current implementation failed for stream-readable, i.e. a transform created via through2
- namely 'instance of stream' returns false
- identifying readable stream by checking for _readableState fixes this issue
