### PR TITLE
simplifying path vs. stream detection

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -55,10 +55,10 @@ Modem.prototype.dial = function(options, callback) {
   }
 
   if(options.file) {
-    if (stream.Readable ? options.file instanceof stream.Readable : options.file instanceof stream && options.file.readable) {
-      datastream = options.file;
-    } else {
+    if (typeof options.file === 'string') {
       data = fs.readFileSync(p.resolve(options.file));
+    } else {
+      datastream = options.file;
     }
     optionsf.headers['Content-Type'] = 'application/tar';
   } else if(opts && options.method === 'POST') {


### PR DESCRIPTION
This PR is a much simpler alternative to https://github.com/apocas/docker-modem/pull/15 with the same (and arguably even more reliable result).
- simpler to detect string
- if string we assume it is a path to a file
- if not string we assume it is a stream since that is the only other option
