### PR TITLE
Correct optionsf.path in modem.js

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -79,6 +79,7 @@ Modem.prototype.dial = function(options, callback) {
   } else {
     optionsf.hostname = url.parse(address).hostname;
     optionsf.port = url.parse(address).port;
+    optionsf.path = url.parse(address).path;
   }
 
   debug('Sending: %s', util.inspect(optionsf, { showHidden: true, depth: null }));


### PR DESCRIPTION
Corrects optionsf.path in modem.js for http docker hosts. The path incorrect here was not breaking anything in node; however is was not working in browserify. This is also a bug with browserify since it's http request is not mirroring node's behavior, but it is probably good to have the path be accurate anyways.

Before the fix `optionsf.path` was the full href: "http://localhost:4243/{path}" instead of just being "/{path}"
