### PR TITLE
demuxStream: properly end output streams

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -162,6 +162,11 @@ Modem.prototype.demuxStream = function(stream, stdout, stderr) {
       header = stream.read(8);
     }
   });
+
+  stream.on('end', function () {
+    stdout.end();
+    stderr.end();
+  });
 };
 
 module.exports = Modem;


### PR DESCRIPTION
Call the `end` method on the `stdout` and `stderr` stream when the source stream is out of data.
