### PR TITLE
 Committer: moon <moon@ijaal.net>

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -80,6 +80,10 @@ Modem.prototype.dial = function(options, callback) {
     optionsf.hostname = urlp.hostname;
     optionsf.port = urlp.port;
     optionsf.path = urlp.path;
+    if(opts && options.method === 'GET') {
+      optionsf.path = optionsf.path + "?" + querystring.stringify(opts);
+      optionsf.headers['Content-Type'] = "application/json";
+    }
   }
 
   debug('Sending: %s', util.inspect(optionsf, { showHidden: true, depth: null }));


### PR DESCRIPTION
 Adding QS to optionsf.path because when GET method is selected
 no options is passed to following-redirect.http

 Changes to be committed:
    modified:   modem.js
