### PR TITLE
X-Registry-Auth should be now JSON and Base64

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -50,7 +50,11 @@ Modem.prototype.dial = function(options, callback) {
   };
 
   if(options.authconfig) {
-    optionsf.headers['X-Registry-Auth'] = options.authconfig;
+    function base64(s) {
+      new Buffer(s).toString('base64');
+    }
+
+    optionsf.headers['X-Registry-Auth'] = base64(JSON.stringify(options.authconfig));
   }
 
   if(options.file) {


### PR DESCRIPTION
I'm assuming that `cfg.authconfig` is a JSON object of the form:

```
{
    username: "bob",
    password: "password123",
    email: "bob@example.com"
}
```

If that's the case we need to stringify and base64 encode it.
