### PR TITLE
Parse the DOCKER_HOST variable.

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -10,17 +10,33 @@ var querystring = require('querystring'),
 
 var defaultOpts = function() {
   var split;
-  var result = {}
+  var opts = {}
 
   if (process.env.DOCKER_HOST) {
     split = /tcp:\/\/([0-9.]+):([0-9]+)/g.exec(process.env.DOCKER_HOST);
-    result.host = 'http://' + split[1];
-    result.port = split[2];
-  } else {
-    result.socketPath = '/var/run/docker.sock';
+
+    if (process.env.DOCKER_TLS_VERIFY === '1') {
+      opts.protocol = 'https';
+    }
+    else {
+      opts.protocol = 'http';
+    }
+
+    opts.host = split[1];
+
+    if (process.env.DOCKER_CERT_PATH) {
+      opts.ca = fs.readFileSync(path.join(process.env.DOCKER_CERT_PATH, 'ca.pem'));
+      opts.cert = fs.readFileSync(path.join(process.env.DOCKER_CERT_PATH, 'cert.pem'));
+      opts.key = fs.readFileSync(path.join(process.env.DOCKER_CERT_PATH, 'key.pem'));
+    }
+
+    opts.port = split[2];
+  }
+  else {
+    opts.socketPath = '/var/run/docker.sock';
   }
 
-  return result;
+  return opts;
 }
 
 var Modem = function(opts) {


### PR DESCRIPTION
Parse the `DOCKER_HOST` env variable if no option is passed.

Code taken from [nscale](http://github.com/nearform/nscale)
