### PR TITLE
Add support for DOCKER_HOST=unix://

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -12,7 +12,13 @@ var defaultOpts = function() {
   var split;
   var opts = {};
 
-  if (process.env.DOCKER_HOST) {
+  if (!process.env.DOCKER_HOST) {
+    opts.socketPath = '/var/run/docker.sock';
+  } else if (process.env.DOCKER_HOST.indexOf('unix://') == 0) {
+    // Strip off unix://, fall back to default of /var/run/docker.sock if
+    // unix:// was passed without a path
+    opts.socketPath = process.env.DOCKER_HOST.substring(7) || '/var/run/docker.sock';
+  } else {
     split = /tcp:\/\/(.*?):([0-9]+)/g.exec(process.env.DOCKER_HOST);
 
     if (process.env.DOCKER_TLS_VERIFY === '1') {
@@ -35,8 +41,6 @@ var defaultOpts = function() {
     }
 
     opts.port = split[2];
-  } else {
-    opts.socketPath = '/var/run/docker.sock';
   }
 
   return opts;

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var Modem = require('../lib/modem');
+
+describe('Modem', function () {
+  beforeEach(function () { delete process.env.DOCKER_HOST; });
+
+  it('should default to /var/run/docker.sock', function () {
+    var modem = new Modem();
+    assert.ok(modem.socketPath);
+    assert.strictEqual(modem.socketPath, '/var/run/docker.sock');
+  });
+
+  it('should allow DOCKER_HOST=unix:///path/to/docker.sock', function () {
+    process.env.DOCKER_HOST = 'unix:///tmp/docker.sock';
+
+    var modem = new Modem();
+    assert.ok(modem.socketPath);
+    assert.strictEqual(modem.socketPath, '/tmp/docker.sock');
+  });
+
+  it('should interpret DOCKER_HOST=unix:// as /var/run/docker.sock', function () {
+    process.env.DOCKER_HOST = 'unix://';
+
+    var modem = new Modem();
+    assert.ok(modem.socketPath);
+    assert.strictEqual(modem.socketPath, '/var/run/docker.sock');
+  });
+
+  it('should interpret DOCKER_HOST=tcp://N.N.N.N:2376 as https', function () {
+    process.env.DOCKER_HOST = 'tcp://192.168.59.103:2376';
+
+    var modem = new Modem();
+    assert.ok(modem.host);
+    assert.ok(modem.port);
+    assert.ok(modem.protocol);
+    assert.strictEqual(modem.host, '192.168.59.103');
+    assert.strictEqual(modem.port, '2376');
+    assert.strictEqual(modem.protocol, 'https');
+  });
+});


### PR DESCRIPTION
The `docker` command and a number of other tools support a `DOCKER_HOST` environment variable in the format `unix:///path/to/docker.sock`. Now `docker-modem`-based apps can too.

I also took the liberty of adding a test for the existing port 2376 TLS behavior.