### PR TITLE
Get error cause from streamed error response bodies

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -200,13 +200,15 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, r
   if (err) return cb(err, null);
 
   if (statusCodes[res.statusCode] !== true) {
-    var msg = new Error(
-      'HTTP code is ' + res.statusCode + ' which indicates error: ' + statusCodes[res.statusCode] + ' - ' + json
-    );
-    msg.reason = statusCodes[res.statusCode];
-    msg.statusCode = res.statusCode;
-    msg.json = json;
-    cb(msg, null);
+    getCause(isStream, res, json, function(err, cause) {
+      var msg = new Error(
+        'HTTP code is ' + res.statusCode + ' which indicates error: ' + statusCodes[res.statusCode] + ' - ' + cause
+      );
+      msg.reason = statusCodes[res.statusCode];
+      msg.statusCode = res.statusCode;
+      msg.json = json;
+      cb(msg, null);
+    });
   } else {
     if (openStdin) {
       cb(null, new HttpDuplex(req, res));
@@ -214,6 +216,20 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, r
       cb(null, res);
     } else {
       cb(null, json);
+    }
+  }
+
+  function getCause(isStream, res, json, callback){
+    var chunks = '';
+    if (isStream) {
+      res.on('data', function(chunk) {
+        chunks += chunk;
+      });
+      res.on('end', function() {
+        callback(null, chunks)
+      });
+    } else {
+      callback(null, json);
     }
   }
 };


### PR DESCRIPTION
Error responses were only included if they were JSON.

This PR adds some code to consume streamed responses, too.