### PR TITLE
Returning body of error responses from streaming responses

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -163,20 +163,8 @@ Modem.prototype.buildRequest = function(options, context, data, callback) {
       self.buildPayload(null, context.isStream, context.statusCodes, context.openStdin, req, res, null, callback);
     } else {
       var chunks = '';
-      res.on('data', function(chunk) {
-        chunks += chunk;
-      });
-
-      res.on('end', function() {
-        debug('Received: %s', chunks);
-
-        var json;
-        try {
-          json = JSON.parse(chunks);
-        } catch(e) {
-          json = chunks;
-        }
-        self.buildPayload(null, context.isStream, context.statusCodes, false, req, res, json, callback);
+      readStream(res, function (error, body) {
+        self.buildPayload(null, context.isStream, context.statusCodes, false, req, res, toJsonOrString(body), callback);
       });
     }
   });
@@ -203,10 +191,21 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, r
     var msg = new Error(
       'HTTP code is ' + res.statusCode + ' which indicates error: ' + statusCodes[res.statusCode] + ' - ' + json
     );
-    msg.reason = statusCodes[res.statusCode];
-    msg.statusCode = res.statusCode;
-    msg.json = json;
-    cb(msg, null);
+
+    function prepareMessage(json) {
+      msg.reason = statusCodes[res.statusCode];
+      msg.statusCode = res.statusCode;
+      msg.json = json;
+      cb(msg, null);
+    }
+
+    if (isStream) {
+      readStream(res, function (error, body) {
+        prepareMessage(toJsonOrString(body));
+      });
+    } else {
+      prepareMessage(json);
+    }
   } else {
     if (openStdin) {
       cb(null, new HttpDuplex(req, res));
@@ -236,5 +235,30 @@ Modem.prototype.demuxStream = function(stream, stdout, stderr) {
     }
   });
 };
+
+function toJsonOrString(string) {
+  var json;
+
+  try {
+    json = JSON.parse(string);
+  } catch(e) {
+    json = string;
+  }
+
+  return json;
+}
+
+function readStream(stream, callback) {
+  var chunks = [];
+  stream.on('data', function (chunk) {
+    chunks.push(chunk);
+  });
+  stream.on('end', function () {
+    callback(undefined, chunks.join(''));
+  });
+  stream.on('error', function (error) {
+    callback(error);
+  });
+}
 
 module.exports = Modem;


### PR DESCRIPTION
For example, when I get an error from [`/images/create`](https://docs.docker.com/reference/api/docker_remote_api_v1.16/#create-an-image) I get no error response message. Hard to see what happened.

I extracted a few functions to make it a bit easier.