### PR TITLE
Ability to send headers

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -102,7 +102,7 @@ Modem.prototype.dial = function(options, callback) {
   var optionsf = {
     path: address,
     method: options.method,
-    headers: {},
+    headers: options.headers,
     key: self.key,
     cert: self.cert,
     ca: self.ca


### PR DESCRIPTION
Our Load balancer have problems receiving client requests with Transfer-Encoding: chunked
This will allow to send custom headers for any requests