### PR TITLE
Allow passing headers when dialling

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -102,7 +102,7 @@ Modem.prototype.dial = function(options, callback) {
   var optionsf = {
     path: address,
     method: options.method,
-    headers: {},
+    headers: options.headers || {},
     key: self.key,
     cert: self.cert,
     ca: self.ca


### PR DESCRIPTION
Working on some dockerode functionality which requires me to send an Authorization header.