### PR TITLE
add key to override authconfig object encoding

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -109,7 +109,8 @@ Modem.prototype.dial = function(options, callback) {
   };
 
   if (options.authconfig) {
-    optionsf.headers['X-Registry-Auth'] = new Buffer(JSON.stringify(options.authconfig)).toString('base64');
+    optionsf.headers['X-Registry-Auth'] = options.authconfig.key ||
+      new Buffer(JSON.stringify(options.authconfig)).toString('base64');
   }
 
   if (options.file) {


### PR DESCRIPTION
I am working currently on a Docker remote API proxy, I already get the AuthConfig object has a base64-encoded string from the request header.

This  patch allow to use a already base64-encoded AuthConfig string instead of a plain AuthConfig object.

