### PR TITLE
added checkServerIdentity override

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -59,6 +59,7 @@ var Modem = function(opts) {
   this.cert = opts.cert;
   this.ca = opts.ca;
   this.timeout = opts.timeout;
+  this.checkServerIdentity = opts.checkServerIdentity;
 
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
@@ -107,6 +108,10 @@ Modem.prototype.dial = function(options, callback) {
     cert: self.cert,
     ca: self.ca
   };
+
+  if (this.checkServerIdentity) {
+    optionsf.checkServerIdentity = this.checkServerIdentity;
+  }
 
   if (options.authconfig) {
     optionsf.headers['X-Registry-Auth'] = options.authconfig.key ||


### PR DESCRIPTION
This allows for the user to define a custom `checkServerIdentity` function to override the default certificate hostname verification function (`tls. checkServerIdentity`)