### PR TITLE
Update JSONStream@0.10 to jsonstream@1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "debug": "~0.7.4",
     "follow-redirects": "0.0.3",
+    "jsonstream": "^1.0.3",
     "querystring": "0.2.0",
-    "readable-stream": "~1.0.26-4",
-    "JSONStream": "0.10.0"
+    "readable-stream": "~1.0.26-4"
   },
   "devDependencies": {
     "chai": "~1.7.0",

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -39,6 +39,7 @@ describe('Modem', function () {
   });
 
   it('should interpret DOCKER_HOST=tcp://N.N.N.N:5555 as http', function () {
+    delete process.env.DOCKER_TLS_VERIFY;
     process.env.DOCKER_HOST = 'tcp://192.168.59.105:5555';
 
     var modem = new Modem();
@@ -48,5 +49,18 @@ describe('Modem', function () {
     assert.strictEqual(modem.host, '192.168.59.105');
     assert.strictEqual(modem.port, '5555');
     assert.strictEqual(modem.protocol, 'http');
+  });
+
+  it('should interpret DOCKER_HOST=tcp://N.N.N.N:5555 as http', function () {
+    process.env.DOCKER_TLS_VERIFY = '1';
+    process.env.DOCKER_HOST = 'tcp://192.168.59.105:5555';
+
+    var modem = new Modem();
+    assert.ok(modem.host);
+    assert.ok(modem.port);
+    assert.ok(modem.protocol);
+    assert.strictEqual(modem.host, '192.168.59.105');
+    assert.strictEqual(modem.port, '5555');
+    assert.strictEqual(modem.protocol, 'https');
   });
 });


### PR DESCRIPTION
There are a lot of problems with JSONStream vs. jsonstream due to
case-folding and case-insensitive filesystems and how npm's cache
works. The best way forward is for everyone to standardize on
jsonstream, which is the canonical name for the module formerly called
JSONStream.

Also fixes a failing test that wasn't accounting for DOCKER_TLS_VERIFY being set in the environment, which is the case when using boot2docker.