### PR TITLE
Make 'tcp://' optional when reading DOCKER_HOST

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -20,7 +20,7 @@ var defaultOpts = function() {
     // unix:// was passed without a path
     opts.socketPath = process.env.DOCKER_HOST.substring(7) || '/var/run/docker.sock';
   } else {
-    split = /tcp:\/\/(.*?):([0-9]+)/g.exec(process.env.DOCKER_HOST);
+    split = /(?:tcp:\/\/)?(.*?):([0-9]+)/g.exec(process.env.DOCKER_HOST);
 
     if (!split || split.length !== 3) {
       throw new Error('DOCKER_HOST env variable should be something like tcp://localhost:1234');

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -63,4 +63,17 @@ describe('Modem', function () {
     assert.strictEqual(modem.port, '5555');
     assert.strictEqual(modem.protocol, 'https');
   });
+
+  it('should accept DOCKER_HOST=N.N.N.N:5555 as http', function () {
+    delete process.env.DOCKER_TLS_VERIFY;
+    process.env.DOCKER_HOST = '192.168.59.105:5555';
+
+    var modem = new Modem();
+    assert.ok(modem.host);
+    assert.ok(modem.port);
+    assert.ok(modem.protocol);
+    assert.strictEqual(modem.host, '192.168.59.105');
+    assert.strictEqual(modem.port, '5555');
+    assert.strictEqual(modem.protocol, 'http');
+  });
 });


### PR DESCRIPTION
This better matches the behaviour of docker itself, so it avoids the
problem of "hey, docker works, why doesn't dockerode?" and some hair
pulling.

@apocas hopefully this PR works out better than #43 did ;-)

/cc @altsang @sam-github