### PR TITLE
Update modem.js

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -125,7 +125,7 @@ Modem.prototype.dial = function(options, callback) {
 
   if (options.file) {
     if (typeof options.file === 'string') {
-      data = fs.readFileSync(path.resolve(options.file));
+      data = fs.createReadStream(path.resolve(options.file));
     } else {
       data = options.file;
     }


### PR DESCRIPTION
you have 2 issues this proposes to fix:
1. you read the tar synchronously. so you're blocking the event loop.
2. you create a single consistent buffer for the entire content of the tar, so a tar of 1GB has no chance of passing.

replacing readFileSync with stream solves these issues.

FYI