### PR TITLE
Stream files rather than load them...

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -125,7 +125,7 @@ Modem.prototype.dial = function(options, callback) {
 
   if (options.file) {
     if (typeof options.file === 'string') {
-      data = fs.readFileSync(path.resolve(options.file));
+      data = fs.createReadStream(path.resolve(options.file));
     } else {
       data = options.file;
     }


### PR DESCRIPTION
Image can be big and if not streamed this will break... Also it's just bad practice as it uses a lot of memory it doesn't need...

This is more of a bug report than a PR, as I didn't test. But from what I can see this simple change should do the trick and have pretty big impact when streaming large image files to docker.