### PR TITLE
removed to url parse on this.host since it's broken

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -82,7 +82,7 @@ Modem.prototype.dial = function(options, callback) {
   if (this.host) {
     address = url.format({
       'protocol': self.protocol,
-      'hostname': self.host,
+      'hostname': self.host.split(":")[0],
       'port': self.port
     });
     address = url.resolve(address, options.path);

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -80,10 +80,9 @@ Modem.prototype.dial = function(options, callback) {
   }
 
   if (this.host) {
-    var parsed = url.parse(self.host);
     address = url.format({
-      'protocol': parsed.protocol || self.protocol,
-      'hostname': parsed.hostname || self.host,
+      'protocol': self.protocol,
+      'hostname': self.host,
       'port': self.port
     });
     address = url.resolve(address, options.path);


### PR DESCRIPTION
The url parse on the host gives wrong results

Example

``` js
url.parse('docker:2764')
{
  protocol: 'docker:',
  slashes: null,
  auth: null,
  host: '2764',
  port: null,
  hostname: '2764',
  hash: null,
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: 'docker:2764' 
}
```

One way to solve it would be adding a protocol ahead but as self.protocol, host and port all exists (and should exists as described in the tests) i don't see any role for the url.parse, except to break the application.
