### PR TITLE
proposal: use upgraded connections for streams

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -142,6 +142,11 @@ Modem.prototype.dial = function(options, callback) {
     optionsf.headers['Content-Length'] = data.length;
   }
 
+  if (options.hijack) {
+    optionsf.headers.Connection = 'Upgrade';
+    optionsf.headers.Upgrade = 'tcp';
+  }
+
   if (this.socketPath) {
     optionsf.socketPath = this.socketPath;
   } else {
@@ -170,6 +175,12 @@ Modem.prototype.buildRequest = function(options, context, data, callback) {
         debug('Timeout of %s ms exceeded', self.timeout);
         req.abort();
       });
+    });
+  }
+
+  if (context.hijack === true) {
+    req.on('upgrade', function(res, sock, head) {
+      return callback(null, sock);
     });
   }
 
@@ -206,7 +217,7 @@ Modem.prototype.buildRequest = function(options, context, data, callback) {
     data.pipe(req);
   }
 
-  if (!context.openStdin && (typeof data === "string" || data === undefined || Buffer.isBuffer(data))) {
+  if (!context.hijack && !context.openStdin && (typeof data === "string" || data === undefined || Buffer.isBuffer(data))) {
     req.end();
   }
 };


### PR DESCRIPTION
Implements the client side of HTTP connection hijacking described in
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#3-2-hijacking

This would allow a raw TCP socket to be passed back instead of using a
custom HTTP Duplex implementation for:
 - POST /containers/(id)/attach
 - POST /exec/(id)/start

It doesn't seem to be completely documented, but it appears that any
endpoint that responds with a `{{ STREAM }}` (muxed stdout/stderr) can
be upgraded to a plain TCP connection.

This implementation works, but isn't complete in that it doesn't
include tests and may not handle all cases. I didn't want to put in
all that effort until there was a discussion about it.

@apocas what do you think?