### PR TITLE
allow for ca certs that contain a chain

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -7,6 +7,7 @@ var querystring = require('querystring'),
   HttpDuplex = require('./http_duplex'),
   debug = require('debug')('modem'),
   util = require('util'),
+  splitca = require('split-ca'),
   JSONStream = require('JSONStream');
 
 var defaultOpts = function() {
@@ -37,7 +38,7 @@ var defaultOpts = function() {
     opts.host = split[1];
 
     if (process.env.DOCKER_CERT_PATH) {
-      opts.ca = fs.readFileSync(path.join(process.env.DOCKER_CERT_PATH, 'ca.pem'));
+      opts.ca = splitca(path.join(process.env.DOCKER_CERT_PATH, 'ca.pem'));
       opts.cert = fs.readFileSync(path.join(process.env.DOCKER_CERT_PATH, 'cert.pem'));
       opts.key = fs.readFileSync(path.join(process.env.DOCKER_CERT_PATH, 'key.pem'));
     }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "docker"
   ],
   "dependencies": {
+    "JSONStream": "0.10.0",
     "debug": "~0.7.4",
     "follow-redirects": "0.0.3",
-    "JSONStream": "0.10.0",
     "querystring": "0.2.0",
-    "readable-stream": "~1.0.26-4"
+    "readable-stream": "~1.0.26-4",
+    "split-ca": "^1.0.0"
   },
   "devDependencies": {
     "chai": "~1.7.0",


### PR DESCRIPTION
For custom CA setups where there are intermediate certificate chains, docker modem needs to support splitting the CA certificate into an array for node.