### PR TITLE
fix connect to https

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -107,8 +107,12 @@ Modem.prototype.dial = function(options, callback) {
     headers: options.headers || {},
     key: self.key,
     cert: self.cert,
-    ca: self.ca
+    ca: self.ca,
   };
+
+  if (self.protocol === 'https') {
+    optionsf.rejectUnauthorized = false;
+  }
 
   if (this.checkServerIdentity) {
     optionsf.checkServerIdentity = this.checkServerIdentity;


### PR DESCRIPTION
Env: Mac OS El Captian, Boot2Docker

```js
{ [Error: unable to verify the first certificate] code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' }
```

to

```js
{ Id: 'b248f6a484ed23198c9a1a3823e0a70fde982ea652a51250202d125bba6631a5',
  Names: [ '/nginx' ],
  Image: 'nginx',
  Command: '/sbin/entrypoint.sh /usr/sbin/nginx',
  Created: 1448264764,
  Ports: 
   [ { IP: '0.0.0.0',
       PrivatePort: 1935,
       PublicPort: 1935,
       Type: 'tcp' },
     { IP: '0.0.0.0', PrivatePort: 80, PublicPort: 80, Type: 'tcp' },
     { PrivatePort: 443, Type: 'tcp' } ],
  Labels: {},
  Status: 'Up 36 minutes' }
```

It solves [https://github.com/apocas/dockerode/issues/197](https://github.com/apocas/dockerode/issues/197)