### PR TITLE
rely on core querystring package

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -1,4 +1,4 @@
-var querystring = require('querystring'),
+var Qs = require('qs'),
   http = require('follow-redirects'),
   fs = require('fs'),
   path = require('path'),
@@ -95,7 +95,7 @@ Modem.prototype.dial = function(options, callback) {
 
   if (options.path.indexOf('?') !== -1) {
     if (opts && Object.keys(opts).length > 0) {
-      address += querystring.stringify(opts);
+      address += Qs.stringify(opts);
     } else {
       address = address.substring(0, address.length - 1);
     }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "JSONStream": "0.10.0",
     "debug": "~0.7.4",
     "follow-redirects": "0.0.3",
+    "qs": "^6.0.1",
     "readable-stream": "~1.0.26-4",
     "split-ca": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "JSONStream": "0.10.0",
     "debug": "~0.7.4",
     "follow-redirects": "0.0.3",
-    "querystring": "0.2.0",
     "readable-stream": "~1.0.26-4",
     "split-ca": "^1.0.0"
   },


### PR DESCRIPTION
@apocas 

this is related to https://github.com/apocas/dockerode/issues/196

it's a tiny change and perhaps _not ready to merge yet_. what do you think about replacing this package with [qs](https://www.npmjs.com/package/qs) which supports nested objects, and should allow:

```js
docker.listContainers({
  "filters": {
    "label": ["staging","env=green"]
  }
});
```

otherwise we can keep things as-is, and I can update the listContainers example showing how to pass filters as a string (which is a bit foreign to work with): e.g. 

```js
docker.listContainers({
  "filters": '{"label": ["staging","env=green"]}'
});
```

please let me know how you'd like to proceed. if you want to use qs, I can test thoroughly and amend this PR.

Thanks!

