### PR TITLE
auto encode querystring option maps as JSON

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -92,10 +92,9 @@ Modem.prototype.dial = function(options, callback) {
     address = options.path;
   }
 
-
   if (options.path.indexOf('?') !== -1) {
     if (opts && Object.keys(opts).length > 0) {
-      address += querystring.stringify(opts);
+      address += this.buildQuerystring(opts);
     } else {
       address = address.substring(0, address.length - 1);
     }
@@ -316,5 +315,17 @@ Modem.prototype.followProgress = function(stream, onFinished, onProgress) {
     onFinished(null, output);
   }
 };
+
+Modem.prototype.buildQuerystring = function(opts) {
+  var clone = {};
+
+  // serialize map values as JSON strings, else querystring truncates.
+  Object.keys(opts).map(function(key, i){
+    clone[key] = (opts[key] && typeof opts[key] === 'object') ?
+      JSON.stringify(opts[key]) : opts[key];
+  });
+
+  return querystring.stringify(clone);
+}
 
 module.exports = Modem;

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -76,4 +76,19 @@ describe('Modem', function () {
     assert.strictEqual(modem.port, '5555');
     assert.strictEqual(modem.protocol, 'http');
   });
+
+  it('should auto encode querystring option maps as JSON', function () {
+    var modem = new Modem();
+
+    var opts = {
+      "limit": 12,
+      "filters": {
+        "label": ["staging", "env=green"]
+      }
+    }
+    var control = 'limit=12&filters={"label"%3A["staging"%2C"env%3Dgreen"]}'
+    var qs = modem.buildQuerystring(opts);
+    assert.strictEqual(decodeURI(qs), control);
+  });
+
 });


### PR DESCRIPTION
this PR provides the `Modem.buildQuerystring` method which will auto-encode map values as JSON strings (which the docker API expects). Previously map values were _silently_ truncated by querystring.stringify. This approach allows more accessible/friendly management of options, for instance when passing labels as seen in this test ::
```
it("should query containers filtering by map of valued labels", function(done){
      docker.listContainers({
        "limit": 3,
        "filters": {
          "label": ["dockerode-test-label","dockerode-test-value-label=assigned"]
        }
      }, function(err, data){
        expect(data.length).to.equal(1);
        done();
      });
    });
```

I choose to use a method for this, as it's monkey-patchable.  A PR will be submitted to the dockerode project testing and documenting this functionality.