### PR TITLE
Converted demux to work on.('data')

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -270,17 +270,23 @@ Modem.prototype.demuxStream = function(stream, stdout, stderr) {
         var header = bufferSlice(8);
         nextDataType = header.readUInt8(0);
         nextDataLength = header.readUInt32BE(4);
+        // It's possible we got a "data" that contains multiple messages
+        // Process the next one
+        processData();
       }
     } else {
-      if (buffer.length > nextDataLength) {
+      if (buffer.length >= nextDataLength) {
         var content = bufferSlice(nextDataLength);
         if (nextDataType === 1) {
           stdout.write(content);
         } else {
           stderr.write(content);
         }
+        nextDataType = null;
+        // It's possible we got a "data" that contains multiple messages
+        // Process the next one
+        processData();
       }
-      nextDataType = null;
     }
   }
 

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -264,7 +264,9 @@ Modem.prototype.demuxStream = function(stream, stdout, stderr) {
   var nextDataLength = null;
   var buffer = new Buffer('');
   function processData(data) {
-    buffer = Buffer.concat([buffer, data]);
+    if (data) {
+      buffer = Buffer.concat([buffer, data]);
+    }
     if (!nextDataType) {
       if (buffer.length >= 8) {
         var header = bufferSlice(8);

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -260,22 +260,37 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, r
 };
 
 Modem.prototype.demuxStream = function(stream, stdout, stderr) {
-  var header = null;
-
-  stream.on('readable', function() {
-    header = header || stream.read(8);
-    while (header !== null) {
-      var type = header.readUInt8(0);
-      var payload = stream.read(header.readUInt32BE(4));
-      if (payload === null) break;
-      if (type == 2) {
-        stderr.write(payload);
-      } else {
-        stdout.write(payload);
+  var nextDataType = null;
+  var nextDataLength = null;
+  var buffer = new Buffer('');
+  function processData(data) {
+    buffer = Buffer.concat([buffer, data]);
+    if (!nextDataType) {
+      if (buffer.length >= 8) {
+        var header = bufferSlice(8);
+        nextDataType = header.readUInt8(0);
+        nextDataLength = header.readUInt32BE(4);
       }
-      header = stream.read(8);
+    } else {
+      if (buffer.length > nextDataLength) {
+        var content = bufferSlice(nextDataLength);
+        if (nextDataType === 1) {
+          stdout.write(content);
+        } else {
+          stderr.write(content);
+        }
+      }
+      nextDataType = null;
     }
-  });
+  }
+
+  function bufferSlice (end) {
+    var out = buffer.slice(0, end);
+    buffer = new Buffer(buffer.slice(end, buffer.length));
+    return out;
+  }
+
+  stream.on('data', processData);
 };
 
 Modem.prototype.followProgress = function(stream, onFinished, onProgress) {


### PR DESCRIPTION
Demux now works using `.on('data')` which prevents read from being called while the stream is in `flowing` mode which can cause the internal buffer to already be drained while trying to read. This implementation borrows heavily from https://github.com/Nathan219/docker-stream-cleanser but is reduced to try to match this use-case as much as possible.

https://nodejs.org/api/stream.html#stream_readable_read_size

> This method should only be called in paused mode. In flowing mode, this method is called automatically until the internal buffer is drained.
