### PR TITLE
Unexpeced errors were not handled correctly

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -227,7 +227,9 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, r
   if (statusCodes[res.statusCode] !== true) {
     getCause(isStream, res, json, function(err, cause) {
       var msg = new Error(
-        'HTTP code is ' + res.statusCode + ' which indicates error: ' + statusCodes[res.statusCode] + ' - ' + cause
+        '(HTTP code ' + res.statusCode + ') '
+        + (statusCodes[res.statusCode] || 'unexpected') + ' - '
+        + (cause.message || cause) + ' '
       );
       msg.reason = statusCodes[res.statusCode];
       msg.statusCode = res.statusCode;


### PR DESCRIPTION
Unexpeced errors were not handled correctly ('undefined') and the cause coming from the json was serialized as `[object Object]` instead of the correct message.

Original error message (start returning 400):
`HTTP code is 400 which indicates error: undefined - [object Object]`

Now:
`(HTTP code 400) unexpected - starting container with HostConfig was deprecated since v1.10 and removed in v1.12`
