### PR TITLE
Add SPDX license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "maintainers": [
     "apocas <petermdias@gmail.com>"
   ],
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "http://github.com/apocas/docker-modem.git"


### PR DESCRIPTION
Packages should include an SPDX-compatible license name in their
package.json. Otherwise a warning will be printed when the module is
installed. This commit adds that field.