### PR TITLE
Newer version of follow-redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "JSONStream": "0.10.0",
     "debug": "~0.7.4",
-    "follow-redirects": "0.0.3",
+    "follow-redirects": "^0.2.0",
     "readable-stream": "~1.0.26-4",
     "split-ca": "^1.0.0"
   },


### PR DESCRIPTION
I was unable to install dockerode using `ied` because follow-redirects 0.0.3 has a bad package.json file* that apparently npm deals with but some other installers can't. This pull request updates the dependency to a newer version of follow-redirects that doesn't have this issue.

I've been using a patched version of docker-modem and dockerode and haven't had any trouble.

* specifically, it lists "underscore": "" in its dependencies, with that empty string for the version.