### PR TITLE
Cleaned up logic for authconfig

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -76,6 +76,11 @@ Modem.prototype.dial = function(options, callback) {
     opts = options.options;
   }
 
+  // Prevent credentials from showing up in URL
+  if (opts && opts.authconfig) {
+    delete opts.authconfig;
+  }
+
   if (this.version) {
     options.path = '/' + this.version + options.path;
   }


### PR DESCRIPTION
Remove authconfig details from the address URL. 
These show up in the logs (docker logs) and are only used in the `X-Registry-Auth` part of the header.