### PR TITLE
Adding a 'Transfer-Encoding' header when using stream

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -147,6 +147,8 @@ Modem.prototype.dial = function(options, callback) {
     optionsf.headers['Content-Length'] = Buffer.byteLength(data);
   } else if (Buffer.isBuffer(data) === true) {
     optionsf.headers['Content-Length'] = data.length;
+  } else {
+    optionsf.headers['Transfer-Encoding'] = 'chunked';
   }
 
   if (options.hijack) {


### PR DESCRIPTION
When using a stream with docker modem there is no header 'Content-Length' since there is no known length to it. The right replacement for that is using the header 'Transfer-Encoding: chunked'.
This can cause problem with docker daemon as an example: when building an image and canceling (by exiting process or destroying connection) omitting this header while using a stream cause the daemon to ignore the dropped connection and continue the build.