### PR TITLE
Remove the 'Transfer-Encoding' header in requests without body

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -147,7 +147,8 @@ Modem.prototype.dial = function(options, callback) {
     optionsf.headers['Content-Length'] = Buffer.byteLength(data);
   } else if (Buffer.isBuffer(data) === true) {
     optionsf.headers['Content-Length'] = data.length;
-  } else {
+  } else if (optionsf.method === 'POST' || optionsf.method === 'PUT') {
+    // Has body
     optionsf.headers['Transfer-Encoding'] = 'chunked';
   }
 


### PR DESCRIPTION
The header `Transfer-Encoding: chunked` prevents docker daemon from closing the opened fds after canceling the log stream.