### PR TITLE
Fix `t` query parameter for `build` command

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -341,7 +341,7 @@ Modem.prototype.buildQuerystring = function(opts) {
 
   // serialize map values as JSON strings, else querystring truncates.
   Object.keys(opts).map(function(key, i) {
-    clone[key] = (opts[key] && typeof opts[key] === 'object') ?
+    clone[key] = (opts[key] && typeof opts[key] === 'object' && key !== 't') ?
       JSON.stringify(opts[key]) : opts[key];
   });
 

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -84,9 +84,10 @@ describe('Modem', function () {
       "limit": 12,
       "filters": {
         "label": ["staging", "env=green"]
-      }
+      },
+      "t": ["repo:latest", "repo:1.0.0"]
     }
-    var control = 'limit=12&filters={"label"%3A["staging"%2C"env%3Dgreen"]}'
+    var control = 'limit=12&filters={"label"%3A["staging"%2C"env%3Dgreen"]}&t=repo%3Alatest&t=repo%3A1.0.0'
     var qs = modem.buildQuerystring(opts);
     assert.strictEqual(decodeURI(qs), control);
   });


### PR DESCRIPTION
As you can see at https://docs.docker.com/engine/api/v1.29/#operation/ImageBuild, the `build` command is the only operation that supports multiple `t=foo&t=bar` parameters instead of everywhere else where it's a JSON array `other=["foo","bar"]`. This minor change allows multiple tags to be specified through the API when building and saves me from having to create a `tmp` tag that I have to retag with the actual tags I want later.