### PR TITLE
Added Basic authentication to secure the Docker API

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -76,6 +76,7 @@ var Modem = function(opts) {
   this.ca = opts.ca;
   this.timeout = opts.timeout;
   this.checkServerIdentity = opts.checkServerIdentity;
+  this.basicAuth = opts.auth;
 
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
@@ -131,6 +132,10 @@ Modem.prototype.dial = function(options, callback) {
 
   if (this.checkServerIdentity) {
     optionsf.checkServerIdentity = this.checkServerIdentity;
+  }
+
+  if (this.basicAuth) {
+    optionsf.headers['Authorization'] = "Basic " + new Buffer(this.basicAuth).toString('base64');
   }
 
   if (options.authconfig) {


### PR DESCRIPTION
The "auth" property of options is Base64-encoded and added as header "Authorization" to every request. This is necessary when the Docker API is secured by Basic HTTP authentication.