### PR TITLE
Fix followProgress() not triggering progress handler

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -309,7 +309,7 @@ Modem.prototype.followProgress = function(stream, onFinished, onProgress) {
   var parser = JSONStream.parse(),
     output = [];
 
-  parser.on('root', onStreamEvent);
+  parser.on('data', onStreamEvent);
   parser.on('error', onStreamError);
   parser.on('end', onStreamEnd);
 
@@ -332,7 +332,7 @@ Modem.prototype.followProgress = function(stream, onFinished, onProgress) {
   }
 
   function onStreamError(err) {
-    parser.removeListener('root', onStreamEvent);
+    parser.removeListener('data', onStreamEvent);
     parser.removeListener('error', onStreamError);
     parser.removeListener('end', onStreamEnd);
     onFinished(err, output);


### PR DESCRIPTION
Change modem.followProgress() to listen for `data` event instead of `root` since `root` will never get fired.

Current behavior: https://github.com/apocas/dockerode/issues/439#issue-302058751

After the fix
![after](https://user-images.githubusercontent.com/18181641/36942557-0f1e5c16-1f2a-11e8-9bc0-d06f1f595429.gif)
