### PR TITLE
Stream data directly from file system instead of loading it in memory

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -145,7 +145,7 @@ Modem.prototype.dial = function(options, callback) {
 
   if (options.file) {
     if (typeof options.file === 'string') {
-      data = fs.readFileSync(path.resolve(options.file));
+      data = fs.createReadStream(path.resolve(options.file));
     } else {
       data = options.file;
     }


### PR DESCRIPTION
Closes #79 

Blocking node event loop and loading the whole file in memory has a pretty bad impact on apps. Especially for large containers.

This is a very minimal fix that stream the file directly to docker. The support was already there but the way of reading the file was wrong.

Tested to be even in resource-constrained systems.