### PR TITLE
Custom HTTP Agent Support

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -76,6 +76,7 @@ var Modem = function(opts) {
   this.ca = opts.ca;
   this.timeout = opts.timeout;
   this.checkServerIdentity = opts.checkServerIdentity;
+  this.agent = opts.agent;
 
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
@@ -126,7 +127,8 @@ Modem.prototype.dial = function(options, callback) {
     headers: options.headers || {},
     key: self.key,
     cert: self.cert,
-    ca: self.ca
+    ca: self.ca,
+    agent: self.agent,
   };
 
   if (this.checkServerIdentity) {

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -8,8 +8,8 @@ function parseJSON(s) {
 
 var querystring = require('querystring'),
   http = require('./http'),
-  nativeHttpAgent = require('http').Agent,
-  nativeHttpsAgent = require('https').Agent,
+  NativeHttpAgent = require('http').Agent,
+  NativeHttpsAgent = require('https').Agent,
   fs = require('fs'),
   path = require('path'),
   url = require('url'),
@@ -84,12 +84,12 @@ var Modem = function(opts) {
   }
   this.protocol = opts.protocol || this.protocol || 'http';
 
-  if (typeof opts.agent === 'object' && !(opts.agent instanceof nativeHttpAgent) && this.protocol === 'http') {
-    this.agent = new nativeHttpAgent(opts.agent);
-  } else if (typeof opts.agent === 'object' && !(opts.agent instanceof nativeHttpsAgent) && this.protocol === 'https') {
-    this.agent = new nativeHttpsAgent(opts.agent);
+  if (typeof opts.agent === 'object' && !(opts.agent instanceof NativeHttpAgent) && this.protocol === 'http') {
+    this.agent = new NativeHttpAgent(opts.agent);
+  } else if (typeof opts.agent === 'object' && !(opts.agent instanceof NativeHttpsAgent) && this.protocol === 'https') {
+    this.agent = new NativeHttpsAgent(opts.agent);
   } else {
-    this.agent = opts.agent
+    this.agent = opts.agent;
   }
 };
 

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -8,6 +8,8 @@ function parseJSON(s) {
 
 var querystring = require('querystring'),
   http = require('./http'),
+  nativeHttpAgent = require('http').Agent,
+  nativeHttpsAgent = require('https').Agent,
   fs = require('fs'),
   path = require('path'),
   url = require('url'),
@@ -76,12 +78,19 @@ var Modem = function(opts) {
   this.ca = opts.ca;
   this.timeout = opts.timeout;
   this.checkServerIdentity = opts.checkServerIdentity;
-  this.agent = opts.agent;
 
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
   }
   this.protocol = opts.protocol || this.protocol || 'http';
+
+  if (typeof opts.agent === 'object' && !(opts.agent instanceof nativeHttpAgent) && this.protocol === 'http') {
+    this.agent = new nativeHttpAgent(opts.agent);
+  } else if (typeof opts.agent === 'object' && !(opts.agent instanceof nativeHttpsAgent) && this.protocol === 'https') {
+    this.agent = new nativeHttpsAgent(opts.agent);
+  } else {
+    this.agent = opts.agent
+  }
 };
 
 Modem.prototype.dial = function(options, callback) {

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -106,7 +106,7 @@ describe('Modem', function() {
 
   it('should use default http agent when no agent is specified', function() {
     var modem = new Modem();
-    assert.strictEqual(modem.agent, undefined);
+    assert.strictEqual(typeof modem.agent, 'undefined');
   });
 
   it('should disable http pooling when agent is false', function() {

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -131,22 +131,22 @@ describe('Modem', function() {
   });
 
   it('should use custom http agent when opts are an http.Agent instance with http protocol', function() {
-    var agent = new http.Agent({ keepAlive: true, kaapAliveMsecs: 8000 });
+    var httpAgent = new http.Agent({ keepAlive: true, kaapAliveMsecs: 8000 });
     var modem = new Modem({ 
       protocol: 'http',
-      agent: agent
+      agent: httpAgent
     });
     assert.ok(modem.agent instanceof http.Agent);
-    assert.strictEqual(modem.agent, agent);
+    assert.strictEqual(modem.agent, httpAgent);
   });
 
   it('should use custom http agent when opts are a https.Agent with https protocol', function() {
-    var agent = new https.Agent({ keepAlive: true, kaapAliveMsecs: 8000 });
+    var httpsAgent = new https.Agent({ keepAlive: true, kaapAliveMsecs: 8000 });
     var modem = new Modem({ 
       protocol: 'https',
-      agent: agent
+      agent: httpsAgent
     });
     assert.ok(modem.agent instanceof https.Agent);
-    assert.strictEqual(modem.agent, agent);
+    assert.strictEqual(modem.agent, httpsAgent);
   });
 });

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -1,4 +1,6 @@
 var assert = require('assert');
+var http = require('http');
+var https = require('https');
 var Modem = require('../lib/modem');
 
 describe('Modem', function() {
@@ -102,4 +104,49 @@ describe('Modem', function() {
     assert.strictEqual(modem.timeout, 3000);
   });
 
+  it('should use default http agent when no agent is specified', function() {
+    var modem = new Modem();
+    assert.strictEqual(modem.agent, undefined);
+  });
+
+  it('should disable http pooling when agent is false', function() {
+    var modem = new Modem({ agent: false });
+    assert.strictEqual(modem.agent, false);
+  });
+
+  it('should use custom http agent when opts are specified with http protocol', function() {
+    var modem = new Modem({ 
+      protocol: 'http',
+      agent: { keepAlive: true, kaapAliveMsecs: 8000 }
+    });
+    assert.ok(modem.agent instanceof http.Agent);
+  });
+
+  it('should use custom https agent when opts are specified with https protocol', function() {
+    var modem = new Modem({ 
+      protocol: 'https',
+      agent: { keepAlive: true, kaapAliveMsecs: 8000 }
+    });
+    assert.ok(modem.agent instanceof https.Agent);
+  });
+
+  it('should use custom http agent when opts are an http.Agent instance with http protocol', function() {
+    var agent = new http.Agent({ keepAlive: true, kaapAliveMsecs: 8000 });
+    var modem = new Modem({ 
+      protocol: 'http',
+      agent: agent
+    });
+    assert.ok(modem.agent instanceof http.Agent);
+    assert.strictEqual(modem.agent, agent);
+  });
+
+  it('should use custom http agent when opts are a https.Agent with https protocol', function() {
+    var agent = new https.Agent({ keepAlive: true, kaapAliveMsecs: 8000 });
+    var modem = new Modem({ 
+      protocol: 'https',
+      agent: agent
+    });
+    assert.ok(modem.agent instanceof https.Agent);
+    assert.strictEqual(modem.agent, agent);
+  });
 });


### PR DESCRIPTION
I was running into an issue with NodeJS connection pooling that required me to use a custom HTTPS Agent.

This PR allows a custom agent to be passed in using the following logic:

- `undefined` will default to global object
- `false` will disable connection ppoling
- An object containing configuration options will be used to create an Agent based on the protocol
  - `http` protocol will use the http module and `https` will use the https module
- An object that is an instance of `https.Agent` or `https.Agent` will be passed through.