### PR TITLE
add a endCallback for demuxStream

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -286,7 +286,7 @@ Modem.prototype.buildPayload = function(err, isStream, statusCodes, openStdin, r
   }
 };
 
-Modem.prototype.demuxStream = function(stream, stdout, stderr) {
+Modem.prototype.demuxStream = function(stream, stdout, stderr, endCallback) {
   var header = null;
 
   stream.on('readable', function() {
@@ -303,6 +303,7 @@ Modem.prototype.demuxStream = function(stream, stdout, stderr) {
       header = stream.read(8);
     }
   });
+  if (typeof endCallback === 'function') stream.on('end', endCallback);
 };
 
 Modem.prototype.followProgress = function(stream, onFinished, onProgress) {


### PR DESCRIPTION
hi, i use your dockerode in my project
it really awesome!
i use it control docker to run code safety like a sandbox
so i use exec frequently
but in example i cant find the way to get the exec result
i find other people have same demand
[https://github.com/apocas/dockerode/issues/401](https://github.com/apocas/dockerode/issues/401)
then you reply "could just listen for the data and end stream events."
and solve my problem, my code is like

```
var newStream = require('stream');
var logStream = new newStream.PassThrough();
logStream.on('data', function(chunk){
 ... get data ...
});
stream.on('end',function () {
 ... do something for complete data...
})
container.modem.demuxStream(stream, logStream, logStream);
```

i think this demand that get exec result is very common
so maybe can provide a endCallback in demuxStream or just add a example in dockerode
let people can find way faster

thx