### PR TITLE
Return a buffer instead of a chunked string

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -217,15 +217,18 @@ Modem.prototype.buildRequest = function(options, context, data, callback) {
     if (context.isStream === true) {
       self.buildPayload(null, context.isStream, context.statusCodes, context.openStdin, req, res, null, callback);
     } else {
-      var chunks = '';
+      var chunks = [];
       res.on('data', function(chunk) {
-        chunks += chunk;
+        chunks.push(chunk);
       });
 
       res.on('end', function() {
-        debug('Received: %s', chunks);
+        var buffer = Buffer.concat(chunks);
+        var result = buffer.toString();
 
-        var json = parseJSON(chunks) || chunks;
+        debug('Received: %s', result);
+
+        var json = parseJSON(result) || buffer;
         self.buildPayload(null, context.isStream, context.statusCodes, false, req, res, json, callback);
       });
     }


### PR DESCRIPTION
I ran into this problem when trying to get the logs from a container. The string I got back was not parseable. The problem is that converting a Buffer that contains the Docker stream control headers gets mangled in such a way that it cannot be converted back for parsing.

For example, if Docker returns a chunk like this:

```
<Buffer 02 00 00 00 00 00 00 98 5b 54 ... >
```

Converting that to a string and back results in a Buffer that looks like this:

```
<Buffer 02 00 00 00 00 00 00 ef bf bd 5b 54 ... >
```

Notice the two extra bytes, making the header un-parseable. No combination of string encodings changes this, either.

This pull request proposes that instead of concatenating all of the chunks into a string, they are instead concatenated into a larger Buffer, so the end user can manipulate it however they see fit when the result is not valid JSON.