### PR TITLE
Interpret empty object as default opts and fix tests on windows

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -63,7 +63,7 @@ var defaultOpts = function() {
 };
 
 var Modem = function(opts) {
-  if (!opts) {
+  if (!opts || (Object.keys(opts).length === 0 && opts.constructor === Object)) {
     opts = defaultOpts();
   }
 

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -1,15 +1,27 @@
 var assert = require('assert');
 var Modem = require('../lib/modem');
+var defaultSocketPath = require('os').type() === 'Windows_NT' ? '//./pipe/docker_engine' : '/var/run/docker.sock';
 
 describe('Modem', function() {
   beforeEach(function() {
     delete process.env.DOCKER_HOST;
   });
 
-  it('should default to /var/run/docker.sock', function() {
+  it('should default to default socket path', function() {
     var modem = new Modem();
     assert.ok(modem.socketPath);
-    assert.strictEqual(modem.socketPath, '/var/run/docker.sock');
+    assert.strictEqual(modem.socketPath, defaultSocketPath);
+  });
+
+  it('should default to default socket path with empty object argument', function() {
+    var modem = new Modem({});
+    assert.ok(modem.socketPath);
+    assert.strictEqual(modem.socketPath, defaultSocketPath);
+  });
+
+  it('should not default to default socket path with non-empty object argument', function () {
+    var modem = new Modem({a: 'b'});
+    assert.strictEqual(modem.socketPath, undefined);
   });
 
   it('should allow DOCKER_HOST=unix:///path/to/docker.sock', function() {


### PR DESCRIPTION
uses default opts if someone does 'new Modem({ })' with empty argument. Also adds two new tests and fixes an existing one to run on windows. 