### PR TITLE
Return string rather than Buffer on response

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -228,7 +228,7 @@ Modem.prototype.buildRequest = function(options, context, data, callback) {
 
         debug('Received: %s', result);
 
-        var json = parseJSON(result) || buffer;
+        var json = parseJSON(result) || result;
         self.buildPayload(null, context.isStream, context.statusCodes, false, req, res, json, callback);
       });
     }


### PR DESCRIPTION
In previous versions of Dockerode, this was expected behaviour. 2.5.8 broke this, and now returns a Buffer when the `parseJSON` fails. This PR returns the stringified buffer even when this fails, rather than the Buffer object.