### PR TITLE
Add pathPrefix option

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -157,10 +157,10 @@ Modem.prototype.dial = function (options, callback) {
   var optionsf = {
     path: address,
     method: options.method,
-    headers: options.headers || Object.assign({}, self.headers),
-    key: self.key,
-    cert: self.cert,
-    ca: self.ca
+    headers: options.headers || Object.assign({}, this.headers),
+    key: this.key,
+    cert: this.cert,
+    ca: this.ca
   };
 
 

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -11,12 +11,11 @@ var querystring = require('querystring'),
   fs = require('fs'),
   path = require('path'),
   url = require('url'),
-  stream = require('readable-stream'),
-  HttpDuplex = require('./http_duplex'),
-  debug = require('debug')('modem'),
   util = require('util'),
+  debug = require('debug')('modem'),
   splitca = require('split-ca'),
   JSONStream = require('JSONStream'),
+  HttpDuplex = require('./http_duplex'),
   isWin = require('os').type() === 'Windows_NT';
 
 var defaultOpts = function() {
@@ -46,6 +45,13 @@ var defaultOpts = function() {
       opts.protocol = 'http';
     }
 
+    if (process.env.DOCKER_PATH_PREFIX) {
+      opts.pathPrefix = process.env.DOCKER_PATH_PREFIX;
+    }
+    else {
+      opts.pathPrefix = '/';
+    }
+
     opts.host = split[1];
 
     if (process.env.DOCKER_CERT_PATH) {
@@ -70,6 +76,7 @@ var Modem = function(opts) {
   this.socketPath = opts.socketPath;
   this.host = opts.host;
   this.port = opts.port;
+  this.pathPrefix = opts.pathPrefix;
   this.version = opts.version;
   this.key = opts.key;
   this.cert = opts.cert;
@@ -85,7 +92,6 @@ var Modem = function(opts) {
 
 Modem.prototype.dial = function(options, callback) {
   var opts, address, data;
-  var self = this;
 
   if (options.options) {
     opts = options.options;
@@ -101,11 +107,12 @@ Modem.prototype.dial = function(options, callback) {
   }
 
   if (this.host) {
-    var parsed = url.parse(self.host);
+    var parsed = url.parse(this.host);
     address = url.format({
-      'protocol': parsed.protocol || self.protocol,
-      'hostname': parsed.hostname || self.host,
-      'port': self.port
+      protocol: parsed.protocol || this.protocol,
+      hostname: parsed.hostname || this.host,
+      port: this.port,
+      pathname: parsed.pathname || this.pathPrefix,
     });
     address = url.resolve(address, options.path);
   } else {
@@ -124,9 +131,9 @@ Modem.prototype.dial = function(options, callback) {
     path: address,
     method: options.method,
     headers: options.headers || {},
-    key: self.key,
-    cert: self.cert,
-    ca: self.ca
+    key: this.key,
+    cert: this.cert,
+    ca: this.ca
   };
 
   if (this.checkServerIdentity) {


### PR DESCRIPTION
This commit add path prefix for nested HTTP APIs with customized routing. For example I can mount docker's api proxy to `/system/docker/` on my server.

Also:
* Add DOCKER_PATH_PREFIX env variable
* Cleanup dependencies
* Remove redundant self variable
* Reorder dependencies