### PR TITLE
allow custome http/s agent

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -76,6 +76,7 @@ var Modem = function(opts) {
   this.ca = opts.ca;
   this.timeout = opts.timeout;
   this.checkServerIdentity = opts.checkServerIdentity;
+  this.agent = opts.agent;
 
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
@@ -131,6 +132,10 @@ Modem.prototype.dial = function(options, callback) {
 
   if (this.checkServerIdentity) {
     optionsf.checkServerIdentity = this.checkServerIdentity;
+  }
+
+  if (this.agent) {
+    optionsf.agent = this.agent;
   }
 
   if (options.authconfig) {


### PR DESCRIPTION
I have many requests to the docker deamon. Now the number of TCP connections is increasing very fast. For me there are now several thousand connections, which are no longer used, but are not cleaned up by the OS yet. 
That's why I want to use my own agent for the http request. 
With this change I only have a few connections left to the Docker Daemon.

Now I can define the agent as follows:
const docker = new Docker({
    "protocol": "http",
    "host": "127.0.0.1",
    "port": "2375",
    "agent": new http.Agent({
      "keepAlive": true,
      "maxSockets": 10,
      "keepAliveMsecs": 10000
    })
  });