### PR TITLE
Use constructor 'opts' attribute to override default configuration ad…

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -62,10 +62,8 @@ var defaultOpts = function() {
   return opts;
 };
 
-var Modem = function(opts) {
-  if (!opts || (Object.keys(opts).length === 0 && opts.constructor === Object)) {
-    opts = defaultOpts();
-  }
+var Modem = function(options) {
+  var opts = Object.assign({}, defaultOpts(), options);
 
   this.socketPath = opts.socketPath;
   this.host = opts.host;
@@ -76,6 +74,7 @@ var Modem = function(opts) {
   this.ca = opts.ca;
   this.timeout = opts.timeout;
   this.checkServerIdentity = opts.checkServerIdentity;
+  this.headers = opts.headers || {};
 
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
@@ -123,7 +122,7 @@ Modem.prototype.dial = function(options, callback) {
   var optionsf = {
     path: address,
     method: options.method,
-    headers: options.headers || {},
+    headers: options.headers || self.headers,
     key: self.key,
     cert: self.cert,
     ca: self.ca

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -13,15 +13,13 @@ describe('Modem', function() {
     assert.strictEqual(modem.socketPath, defaultSocketPath);
   });
 
-  it('should default to default socket path with empty object argument', function() {
-    var modem = new Modem({});
+  it('should use default value if argument not defined in constructor parameter object', function () {
+    var customHeaders = {host: 'my-custom-host'};
+    var modem = new Modem({headers: customHeaders});
+    assert.ok(modem.headers);
     assert.ok(modem.socketPath);
     assert.strictEqual(modem.socketPath, defaultSocketPath);
-  });
-
-  it('should not default to default socket path with non-empty object argument', function () {
-    var modem = new Modem({a: 'b'});
-    assert.strictEqual(modem.socketPath, undefined);
+    assert.strictEqual(modem.headers, customHeaders);
   });
 
   it('should allow DOCKER_HOST=unix:///path/to/docker.sock', function() {


### PR DESCRIPTION
…d default header attribute

This PR add a default header attribute to specify for example a host or a specific user-agent, and add capability to override default configuration when calling the Modem constructor with an object.

```
const docker = new Docker({
  'headers': {
    'user-agent': 'my-specific-user-agent',
    'host': 'my-specific-host',
  },
});
```
Fix https://github.com/apocas/docker-modem/issues/67 & https://github.com/apocas/dockerode/issues/302
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>