### PR TITLE
Support npipe:// in DOCKER_HOST

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -25,6 +25,10 @@ var defaultOpts = function() {
     // Strip off unix://, fall back to default of /var/run/docker.sock if
     // unix:// was passed without a path
     opts.socketPath = process.env.DOCKER_HOST.substring(7) || '/var/run/docker.sock';
+  } else if (process.env.DOCKER_HOST.indexOf('npipe://') === 0) {
+    // Strip off npipe://, fall back to default of //./pipe/docker_engine if
+    // npipe:// was passed without a path
+    opts.socketPath = process.env.DOCKER_HOST.substring(8) || '//./pipe/docker_engine';
   } else {
     var hostStr = process.env.DOCKER_HOST;
     if(hostStr.indexOf('\/\/') < 0) {


### PR DESCRIPTION
In Windows, `DOCKER_HOST` can contain things like `npipe:////./pipe/docker_engine` or `npipe:////./pipe/docker_wsl`.

Currently it isn't possible to use `DOCKER_HOST` = `npipe:////./pipe/docker_wsl` to use the WSL2 Docker engine; rather, you must pass in `socketPath` to dockerode. If you try using the above for `DOCKER_HOST` you'll get an error.