### PR TITLE
Accept username and agent for SSH

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -44,6 +44,9 @@ var defaultOpts = function() {
 
     if (process.env.DOCKER_TLS_VERIFY === '1' || opts.port === '2376') {
       opts.protocol = 'https';
+    } else if (host.protocol === 'ssh:') {
+      opts.protocol = 'ssh';
+      opts.username = host.username;
     } else {
       opts.protocol = 'http';
     }
@@ -71,6 +74,7 @@ var Modem = function(options) {
   this.socketPath = opts.socketPath;
   this.host = opts.host;
   this.port = opts.port;
+  this.username = opts.username;
   this.version = opts.version;
   this.key = opts.key;
   this.cert = opts.cert;
@@ -201,7 +205,7 @@ Modem.prototype.buildRequest = function(options, context, data, callback) {
   var connectionTimeoutTimer;
 
   var opts = self.protocol === 'ssh' ? Object.assign(options, {
-    agent: ssh({'host': self.host, 'port': self.port}),
+    agent: ssh({'host': self.host, 'port': self.port, 'username': self.username, 'agent': process.env.SSH_AUTH_SOCK}),
     protocol: 'http'
   }) : options;
 

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -206,7 +206,7 @@ Modem.prototype.buildRequest = function(options, context, data, callback) {
 
   var opts = self.protocol === 'ssh' ? Object.assign(options, {
     agent: ssh({'host': self.host, 'port': self.port, 'username': self.username, 'agent': process.env.SSH_AUTH_SOCK}),
-    protocol: 'http'
+    protocol: 'http:'
   }) : options;
 
   var req = http[self.protocol === 'ssh' ? 'http': self.protocol].request(opts, function() {});


### PR DESCRIPTION
Resolves #107 

* Allow SSH `DOCKER_HOST` URLs
* Accept username in `DOCKER_HOST`, i.e. `ssh://user@host`
* Use `SSH_AUTH_SOCK` env var to determine auth agent (Docker CLI also requires `ssh-agent` to be set up)