### PR TITLE
Support SSH password authentication

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -75,6 +75,7 @@ var Modem = function (options) {
   this.host = opts.host;
   this.port = opts.port;
   this.username = opts.username;
+  this.password = opts.password;
   this.version = opts.version;
   this.key = opts.key;
   this.cert = opts.cert;
@@ -206,7 +207,7 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
   var connectionTimeoutTimer;
 
   var opts = self.protocol === 'ssh' ? Object.assign(options, {
-    agent: ssh({ 'host': self.host, 'port': self.port, 'username': self.username, 'agent': self.sshAuthAgent }),
+    agent: ssh({ 'host': self.host, 'port': self.port, 'username': self.username, 'password': self.password, 'agent': self.sshAuthAgent }),
     protocol: 'http:'
   }) : options;
 


### PR DESCRIPTION
SSH password authentication is quite common and with a strong password can be quite secure. Let's support it in `docker-modem` and `dockerode`.

All that's needed to support it is to pass `opts.password` through to the underlying `ssh` library :)