### PR TITLE
Support agent forwarding over SSH

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -84,6 +84,7 @@ var Modem = function (options) {
   this.connectionTimeout = opts.connectionTimeout;
   this.checkServerIdentity = opts.checkServerIdentity;
   this.agent = opts.agent;
+  this.agentForward = opts.agentForward;
   this.headers = opts.headers || {};
   this.sshAuthAgent = opts.sshAuthAgent;
 
@@ -207,7 +208,7 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
   var connectionTimeoutTimer;
 
   var opts = self.protocol === 'ssh' ? Object.assign(options, {
-    agent: ssh({ 'host': self.host, 'port': self.port, 'username': self.username, 'password': self.password, 'agent': self.sshAuthAgent }),
+    agent: ssh({ 'host': self.host, 'port': self.port, 'username': self.username, 'password': self.password, 'agent': self.sshAuthAgent, 'agentForward': self.agentForward }),
     protocol: 'http:'
   }) : options;
 


### PR DESCRIPTION
Like #117, add a common SSH option supported by [ssh2](https://github.com/mscdex/ssh2#client-methods).
All we need to do is pass it in the constructor.