### PR TITLE
Allow arbitrary sshOptions to be passed to ssh2

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -46,7 +46,9 @@ var defaultOpts = function () {
     } else if (host.protocol === 'ssh:') {
       opts.protocol = 'ssh';
       opts.username = host.username;
-      opts.sshAuthAgent = process.env.SSH_AUTH_SOCK;
+      opts.sshOptions = {
+        agent: process.env.SSH_AUTH_SOCK,
+      }
     } else {
       opts.protocol = 'http';
     }
@@ -69,7 +71,8 @@ var defaultOpts = function () {
 
 
 var Modem = function (options) {
-  var opts = Object.assign({}, defaultOpts(), options);
+  var optDefaults = defaultOpts();
+  var opts = Object.assign({}, optDefaults, options);
 
   this.socketPath = opts.socketPath;
   this.host = opts.host;
@@ -85,7 +88,7 @@ var Modem = function (options) {
   this.checkServerIdentity = opts.checkServerIdentity;
   this.agent = opts.agent;
   this.headers = opts.headers || {};
-  this.sshAuthAgent = opts.sshAuthAgent;
+  this.sshOptions = Object.assign({}, options ? options.sshOptions : {}, optDefaults.sshOptions);
 
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
@@ -207,8 +210,13 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
   var connectionTimeoutTimer;
 
   var opts = self.protocol === 'ssh' ? Object.assign(options, {
-    agent: ssh({ 'host': self.host, 'port': self.port, 'username': self.username, 'password': self.password, 'agent': self.sshAuthAgent }),
-    protocol: 'http:'
+    agent: ssh(Object.assign({}, self.sshOptions, {
+      'host': self.host,
+      'port': self.port,
+      'username': self.username,
+      'password': self.password,
+    })),
+    protocol: 'http:',
   }) : options;
 
   var req = http[self.protocol === 'ssh' ? 'http' : self.protocol].request(opts, function () { });

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -90,6 +90,11 @@ var Modem = function (options) {
   this.headers = opts.headers || {};
   this.sshOptions = Object.assign({}, options ? options.sshOptions : {}, optDefaults.sshOptions);
 
+  // Support sshAuthAgent for backwards-compatibility with d2f92b22cf284d537a57cc255ba11b4c4c5d7b61
+  if (options && options.sshAuthAgent) {
+    this.sshOptions.agent = options.sshAuthAgent;
+  }
+
   if (this.key && this.cert && this.ca) {
     this.protocol = 'https';
   }

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -169,4 +169,14 @@ describe('Modem', function() {
     assert.strictEqual(modem.sshOptions.agent, '/var/lib/sock');
     assert.strictEqual(modem.sshOptions.foo, 'bar');
   });
+
+  it('supports custom sshAuthAgent for backwards-compatibility', function() {
+    process.env.DOCKER_HOST = 'ssh://user@192.168.59.105:5555';
+    process.env.SSH_AUTH_SOCK = '/var/lib/sock';
+
+    var modem = new Modem({
+      sshAuthAgent: '/var/lib/custom_agent',
+    });
+    assert.strictEqual(modem.sshOptions.agent, '/var/lib/custom_agent');
+  });
 });

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -144,4 +144,29 @@ describe('Modem', function() {
     assert.ok(modem.agent instanceof http.Agent);
     assert.strictEqual(modem.agent, httpAgent);
   });
+
+  it('should set default ssh agent options from DOCKER_HOST', function() {
+    process.env.DOCKER_HOST = 'ssh://user@192.168.59.105:5555';
+    process.env.SSH_AUTH_SOCK = '/var/lib/sock';
+
+    var modem = new Modem();
+    assert.strictEqual(modem.protocol, 'ssh');
+    assert.strictEqual(modem.username, 'user');
+    assert.ok(modem.sshOptions);
+    assert.strictEqual(modem.sshOptions.agent, '/var/lib/sock');
+  });
+
+  it('should combine custom ssh agent options', function() {
+    process.env.DOCKER_HOST = 'ssh://user@192.168.59.105:5555';
+    process.env.SSH_AUTH_SOCK = '/var/lib/sock';
+
+    var modem = new Modem({
+      sshOptions: {
+        foo: 'bar', // options are arbitrary, whatever ssh2 supports
+      },
+    });
+    assert.ok(modem.sshOptions);
+    assert.strictEqual(modem.sshOptions.agent, '/var/lib/sock');
+    assert.strictEqual(modem.sshOptions.foo, 'bar');
+  });
 });


### PR DESCRIPTION
This allows for an arbitrary `sshOptions` to be passed in `Modem` options and be used when passed to the `ssh` constructor to get an agent from the `ssh2` library.

Tests are added to be sure we're still respecting the `SSH_AUTH_SOCK` env var.