### PR TITLE
Multiplex over ssh

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -1,14 +1,19 @@
 var Client = require('ssh2').Client,
   http = require('http');
+var debug = require('debug')('modem.ssh');
 
 module.exports = function(opt) {
   var conn = new Client();
   var agent = new http.Agent();
 
   agent.createConnection = function(options, fn) {
+    debug('createConnection');
     conn.once('ready', function() {
+      debug('ready');
       conn.exec('docker system dial-stdio', function(err, stream) {
+        debug("dialed")
         if (err) {
+          debug('error');
           conn.end();
           agent.destroy();
           return;
@@ -17,13 +22,17 @@ module.exports = function(opt) {
         fn(null, stream);
 
         stream.once('close', () => {
+          debug('close');
           conn.end();
           agent.destroy();
         });
       });
     }).connect(opt);
 
-    conn.once('end', () => agent.destroy());
+    conn.once('end', () => {
+      debug('end')
+      agent.destroy()
+    });
   };
 
   return agent;

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -3,11 +3,11 @@ var Client = require('ssh2').Client,
 var debug = require('debug')('modem.ssh');
 
 module.exports = function(opt) {
-  var conn = new Client();
   var agent = new http.Agent();
 
   agent.createConnection = function(options, fn) {
     debug('createConnection');
+    var conn = new Client();
     conn.once('ready', function() {
       debug('ready');
       conn.exec('docker system dial-stdio', function(err, stream) {
@@ -15,7 +15,6 @@ module.exports = function(opt) {
         if (err) {
           debug('error');
           conn.end();
-          agent.destroy();
           return;
         }
 
@@ -24,15 +23,9 @@ module.exports = function(opt) {
         stream.once('close', () => {
           debug('close');
           conn.end();
-          agent.destroy();
         });
       });
     }).connect(opt);
-
-    conn.once('end', () => {
-      debug('end')
-      agent.destroy()
-    });
   };
 
   return agent;

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -4,29 +4,44 @@ var debug = require('debug')('modem.ssh');
 
 module.exports = function(opt) {
   var agent = new http.Agent();
+  var conn = new Client();
+  var ready = false;
 
   agent.createConnection = function(options, fn) {
-    debug('createConnection');
-    var conn = new Client();
-    conn.once('ready', function() {
-      debug('ready');
-      conn.exec('docker system dial-stdio', function(err, stream) {
-        debug("dialed")
-        if (err) {
-          debug('error');
-          conn.end();
-          return;
-        }
-
-        fn(null, stream);
-
-        stream.once('close', () => {
-          debug('close');
-          conn.end();
-        });
-      });
-    }).connect(opt);
+    debug('createConnection')
+    if (ready) {
+      dial(conn, fn);
+    } else {
+      conn.once('ready', function() {
+        ready = true;
+        debug('ready');
+        dial(conn, fn);
+      }).connect(opt);
+    }
   };
+
+  agent.destroy_without_ssh = agent.destroy;
+  agent.destroy = function() {
+    conn.end();
+    agent.destroy_without_ssh();
+  }
 
   return agent;
 };
+
+function dial(conn, fn) {
+  conn.exec('docker system dial-stdio', function(err, stream) {
+    debug('dialed')
+    if (err) {
+      debug('error');
+      return;
+    }
+
+    fn(null, stream);
+
+    stream.once('close', () => {
+      debug('close')
+      stream.end();
+    });
+  });
+}


### PR DESCRIPTION
Does this seem like a useful change for docker-modem?  For my purposes, it means both a performance boost and improved ability to use docker-modem (and dockerode) without running ssh-agent.  

I'm building on some ideas from [this comment about running without ssh-agent](https://github.com/apocas/docker-modem/pull/119#issuecomment-703002880).