### PR TITLE
Handle build data input stream errors correctly

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -285,6 +285,9 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
   if (typeof data === 'string' || Buffer.isBuffer(data)) {
     req.write(data);
   } else if (data) {
+    data.on('error', function (error) {
+      req.destroy(error);
+    });
     data.pipe(req);
   }
 


### PR DESCRIPTION
Node's `readable.pipe()` does not forward errors of input streams to the writable stream. This causes the build request to just hang. `stream.pipeline()` available in Node >= 10.0 would solve this problem, but it seems more reasonable to just call `req.destroy(error)` on input stream errors for backwards compatibility.