### PR TITLE
Fix socket hung up for concurrent requests

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -2,10 +2,10 @@ var Client = require('ssh2').Client,
   http = require('http');
 
 module.exports = function(opt) {
-  var conn = new Client();
   var agent = new http.Agent();
-
+  
   agent.createConnection = function(options, fn) {
+    var conn = new Client();
     conn.once('ready', function() {
       conn.exec('docker system dial-stdio', function(err, stream) {
         if (err) {


### PR DESCRIPTION
When doing parallel requests over SSH it may result in a socket hung up, due to a shared client instance. This PR resolves this issue by instantiating a new client per request. Ideally, this will be solved by SSH multiplexing, but this is a simple fix first.