### PR TITLE
Add support for abortSignal, to abort requests with an AbortController

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -117,6 +117,11 @@ Modem.prototype.dial = function (options, callback) {
     delete opts.authconfig;
   }
 
+  // Prevent abortsignal from showing up in the URL
+  if (opts && opts.abortSignal) {
+    delete opts.abortSignal;
+  }
+
   if (this.version) {
     options.path = '/' + this.version + options.path;
   }
@@ -166,6 +171,10 @@ Modem.prototype.dial = function (options, callback) {
   if (options.registryconfig) {
     optionsf.headers['X-Registry-Config'] = options.registryconfig.base64 ||
       Buffer.from(JSON.stringify(options.registryconfig)).toString('base64');
+  }
+
+  if (options.abortSignal) {
+    optionsf.signal = options.abortSignal;
   }
 
   if (options.file) {


### PR DESCRIPTION
This will make it possible to abort Dockerode requests (https://github.com/apocas/dockerode/issues/629). In practice this looks like:

```javascript
const abortController = new AbortController();
modem.dial({
  // ...
  abortSignal: abortController.signal
});

// Later, abort the ongoing request:
abortController.abort();
// -> The request returns an AbortError (code: ABORT_ERROR)
```

I've tested this in Dockerode already, and there will be PR there coming shortly that uses this.

Using this in practice requires either Node 16, or Node 14+ with your own AbortController implementation that polyfills the standard (probably https://www.npmjs.com/package/node-abort-controller).

In other environments nothing breaks, you just can't abort requests, because the `signal` option is ignored by the HTTP module.