### PR TITLE
Don't json-encode array option fields

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -456,7 +456,7 @@ Modem.prototype.buildQuerystring = function (opts) {
 
   // serialize map values as JSON strings, else querystring truncates.
   Object.keys(opts).map(function (key, i) {
-    clone[key] = opts[key] && typeof opts[key] === 'object' && key !== 't' ?
+    clone[key] = opts[key] && typeof opts[key] === 'object' && !Array.isArray(opts[key]) ?
       JSON.stringify(opts[key]) : opts[key];
   });
 


### PR DESCRIPTION
Previously there was a check if the options field has the key `t` to
avoid mistransforming the tags list. On build `extra_hosts` are passed
as a JSON string and wouldn't be applied.

We resolve this through checking for an array.

Fixes https://github.com/apocas/dockerode/issues/605