### PR TITLE
Add exception to json-encode cachefrom option

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -456,8 +456,17 @@ Modem.prototype.buildQuerystring = function (opts) {
 
   // serialize map values as JSON strings, else querystring truncates.
   Object.keys(opts).map(function (key, i) {
-    clone[key] = opts[key] && typeof opts[key] === 'object' && !Array.isArray(opts[key]) ?
-      JSON.stringify(opts[key]) : opts[key];
+    if (opts[key]
+      && typeof opts[key] === 'object'
+      && !Array.isArray(opts[key])
+      // Ref: https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild
+      // > cachefrom (string) JSON array of images used for build cache resolution.
+      || key === 'cachefrom'
+    ) {
+      clone[key] = JSON.stringify(opts[key]);
+    } else {
+      clone[key] = opts[key];
+    }
   });
 
   return querystring.stringify(clone);


### PR DESCRIPTION
After my previous PR which excludes array fields from being transformed
to JSON this was broken.

Sorry, I should have done a full test of all the options before submitting the last patch :P 