### PR TITLE
add base64url encoding for auth header; patch version upgrade

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -8,7 +8,6 @@ var querystring = require('querystring'),
   debug = require('debug')('modem'),
   utils = require('./utils'),
   util = require('util'),
-  url = require('url'),
   splitca = require('split-ca'),
   isWin = require('os').type() === 'Windows_NT';
 
@@ -165,7 +164,7 @@ Modem.prototype.dial = function (options, callback) {
 
   if (options.authconfig) {
     optionsf.headers['X-Registry-Auth'] = options.authconfig.key || options.authconfig.base64 ||
-      Buffer.from(JSON.stringify(options.authconfig)).toString('base64');
+      Buffer.from(JSON.stringify(options.authconfig)).toString('base64').replace(/\+/g, "-").replace(/\//g, "_");
   }
 
   if (options.registryconfig) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docker-modem",
   "description": "Docker remote API network layer module.",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "author": "Pedro Dias <petermdias@gmail.com>",
   "maintainers": [
     "apocas <petermdias@gmail.com>"


### PR DESCRIPTION
Starting from version 1.39, Docker Engine API uses base64url for X-Registry-Auth header encoding. It breakes authentication when password or username contains "~".
https://docs.docker.com/engine/api/v1.41/#section/Authentication
https://datatracker.ietf.org/doc/html/rfc4648#section-5