### PR TITLE
Correctly exclude a few keys from being JSON encoded

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -454,14 +454,13 @@ Modem.prototype.followProgress = function (stream, onFinished, onProgress) {
 Modem.prototype.buildQuerystring = function (opts) {
   var clone = {};
 
-  // serialize map values as JSON strings, else querystring truncates.
+  // serialize map and array values as JSON strings, else querystring truncates.
+  // 't' and 'extrahosts' can be arrays but need special treatment so that they're
+  // passed as multiple qs parameters instead of JSON values.
   Object.keys(opts).map(function (key, i) {
     if (opts[key]
       && typeof opts[key] === 'object'
-      && !Array.isArray(opts[key])
-      // Ref: https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild
-      // > cachefrom (string) JSON array of images used for build cache resolution.
-      || key === 'cachefrom'
+      && !['t', 'extrahosts'].includes(key)
     ) {
       clone[key] = JSON.stringify(opts[key]);
     } else {


### PR DESCRIPTION
Most Docker API parameters take JSON values but some array parameters must be passed as multiple querystring parameters. Two known such parameters are `t` and `extrahosts` for the `/build` endpoint. There may be others.

This changes Modem to behave in a similar way: encode values to JSON by default, except the known special cases.

This properly fixes https://github.com/apocas/dockerode/issues/605 and #139 and effectively reverts #133 and #134.