### PR TITLE
Fix #followProgress not catching certain errors

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -426,7 +426,12 @@ Modem.prototype.followProgress = function (stream, onFinished, onProgress) {
     function processLine(line) {
       if (line[line.length - 1] == '\r') line = line.substr(0, line.length - 1);
       if (line.length > 0) {
+        // Stream can contain lines like { error: '...' } which should be treated as errors
+        // instead of assuming that all lines are valid
         var obj = JSON.parse(line);
+        if (Object.keys(obj).includes('error')) {
+          stream.emit('error', new Error(obj.error))
+        }
         output.push(obj);
         if (onProgress) {
           onProgress(obj);


### PR DESCRIPTION
MRE repo here: https://github.com/weiyuan95/dockerode-followprogress-mre - just run `npm i && npm run repro` to see some logged output.

## Issue
`modem.followProgress` seems to not be able to catch certain kinds of errors when building the image, and incorrectly resolves when it should be erroring out.

Looking at the Dockerfile from the MRE:
```Dockerfile
FROM node:16-alpine3.15

WORKDIR /app

COPY NONEXISTENTFILE ./somewhere
```


The image build should obviously be failing since `NONEXISTSTENTFILE` doesn't exist and so can't be copied, yet `followProgress` successfully resolves. I was tracing the code in `buildPayload`, and it looks like the docker API returns a status code of 200, even though there is an error like this from the stream. I've copied the output from the repro as an example.
```
successful response object ->> [
  { stream: 'Step 1/3 : FROM node:16-alpine3.15' },
  { stream: '\n' },
  { stream: ' ---> d550799ce1e9\n' },
  { stream: 'Step 2/3 : WORKDIR /app' },
  { stream: '\n' },
  { stream: ' ---> Using cache\n' },
  { stream: ' ---> 92527246500f\n' },
  { stream: 'Step 3/3 : COPY NONEXISTENTFILE ./somewhere' },
  { stream: '\n' },
  {
    errorDetail: {
      message: 'COPY failed: file not found in build context or excluded by .dockerignore: stat NONEXISTENTFILE: file does not exist'
    },
    error: 'COPY failed: file not found in build context or excluded by .dockerignore: stat NONEXISTENTFILE: file does not exist'
  }
]

followProgress successfully resolved
```

This 200 is probably why this error isn't caught, since only 400s and 500s are considered to be errors. It isn't caught in `followProgress` as well, since errors should already have been caught in `buildPayload` as far as I can tell.



## Fix
Since the Docker API seems to return a 200 (ie. a fundamental issue which we can't really change), I've implemented a simple approach to just check if the object parsed from the stream has an `error` key, and if it does, emit an `error` event. This ensures that the error is correctly passed to the `onFinished` callback in `followProgress`.

## Comments
- I haven't added any tests since I don't think it's possible to test this in this package. It looks like it's only possible to test this in the main `Dockerode` package
- My understanding of streams aren't that good, so feel free to let me know how this fix can be better implemented
- This should probably fix https://github.com/apocas/dockerode/issues/639 as well.