### PR TITLE
Set default `hijack` option to true

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -64,6 +64,10 @@ var defaultOpts = function () {
       opts.timeout = parseInt(process.env.DOCKER_CLIENT_TIMEOUT, 10);
     }
   }
+  
+  // Required for Docker Desktop >= 4.10.0 since DD proxies the docker socket and needs to be informed about the hijacking
+  // See https://github.com/moby/moby/issues/43799
+  opts.hijack = true;
 
   return opts;
 };


### PR DESCRIPTION
I'm on Docker Desktop for ARM Mac 4.11.1 (84025) and I'm experiencing an issue with [dockerode](https://github.com/apocas/dockerode), where writing to `stdin` never reaches the process in my container.

Based on moby/moby#43799, it seems a change in Docker Desktop 4.10.0 requires that the `Connection` and `Upgrade` headers be sent for stream multiplexing to work, since Docker Desktop proxies the docker socket. For further detail see moby/moby#43799.

