### PR TITLE
fix: handles abort signal in response lifecycle

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -9,7 +9,8 @@ var querystring = require('querystring'),
   utils = require('./utils'),
   util = require('util'),
   splitca = require('split-ca'),
-  isWin = require('os').type() === 'Windows_NT';
+  isWin = require('os').type() === 'Windows_NT',
+  { addAbortSignal } = require('stream');
 
 var defaultOpts = function () {
   var host;
@@ -286,6 +287,12 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
         self.buildPayload(null, context.isStream, context.statusCodes, context.openStdin, req, res, null, callback);
       }
     } else {
+      // The native 'request' method only handles aborting during the request lifecycle not the response lifecycle.
+      // We need to make the response stream abortable so that it's destroyed with an error on abort and then
+      // it triggers the request 'error' event
+      if (options.signal != null) {
+        addAbortSignal(options.signal, res)
+      }
       var chunks = [];
       res.on('data', function (chunk) {
         chunks.push(chunk);


### PR DESCRIPTION
**Problem:** the native http/https 'request' method only handles aborting (through AbortSignal) during the request lifecycle not the response lifecycle. It means that if the AbortSignal is triggered while we are processing the response data, it will be ignored an we will the result as if nothing was aborted.

**Example:**
Considering this code:
```ts
import https from 'https'
import { addAbortSignal } from 'stream'

const abortController = new AbortController()
const req = https.request('https://www.google.com', { signal: abortController.signal })

req.on('response', (res) => {
  console.log('res')
  // Fix
  // addAbortSignal(abortController.signal, res)
  const chunks = []
  res.on('data', (chunk: Buffer) => {
    console.log('data', chunk.length)
    chunks.push(chunk)

    // Option 4: request and response "error" events are NOT triggered
    // abortController.abort()
  })
  res.on('end', () => {
    console.log('end', Buffer.concat(chunks).length)
  })
  res.on('error', (e) => console.error('RES ERROR', e))

  // Option 5: request and response "error" events are NOT triggered
  // abortController.abort()
})
req.on('error', (e) => console.error('REQ ERROR', e))

// Option 1: request "error" event is triggered
// abortController.abort()

req.end()

// Option 2: request "error" event is triggered
// abortController.abort()

// Option 3: request "error" event is triggered
// setTimeout(() => abortController.abort(), 5)
```
- If we execute the code as is, we will have no error because we don't abort so we will see the body length as a result.
- If we comment out the `abortController.abort()` for options 1, 2 or 3 then we will see the AbortError in the request `error` event listener which is what we expect
- If we comment out the `abortController.abort()` for options 4 or 5 then we won't see any error and we will finish processing the response and display the body length as a result
- If we comment out the fix `addAbortSignal(abortController.signal, res)` which basically just destroy the `res` stream when the abort signal is triggered, then it will trigger our request and response `error` event listener.

**In docker-modem:**
In the [buildRequest](https://github.com/CoderPad/docker-modem/blob/master/lib/modem.js#L224) method:
- when we expect a stream as a result (`context.isStream !== true`), we directly call the callback with the stream so there is no problem. Also I think it's not the responsibility of this method to handle an abort event that could happen after we call the callback.
- when we don't expect a stream, we have the pattern described above to read the response content before calling the callback which means that if the request is aborted during the response processing, the callback will be called with success parameters instead of an error.

**The fix:**
Same as the example above, we just need to make the response stream "abortable" so that the request ends with an error.