### PR TITLE
Fix Socket closing to early when the buffer has not flushed yet.

### DIFF
--- a/lib/http_duplex.js
+++ b/lib/http_duplex.js
@@ -40,11 +40,16 @@ HttpDuplex.prototype._write = function(chunk, encoding, cb) {
 };
 
 HttpDuplex.prototype.end = function(chunk, encoding, cb) {
-  this._output.socket.destroy();
+  this._output.socket.destroySoon();
   return this.req.end(chunk, encoding, cb);
 };
 
 HttpDuplex.prototype.destroy = function() {
+  this.req.destroy();
+  this._output.socket.destroy();
+};
+
+HttpDuplex.prototype.destroySoon = function() {
   this.req.destroy();
   this._output.socket.destroy();
 };


### PR DESCRIPTION
Hello apocas 😄 

i noticed that Sockets get closed to early when youre calling end on the HttpDuplex Object.
This should fix it as intended by https://nodejs.org/api/net.html#socketdestroysoon

To replicate the issue just try this:
```js
const container = docker.getContainer("1234abcd");
container.attach({ stream: true, stdin: true }, function (err, stream) {
  stream.write("Hello World!\n");
  stream.end();
});
```

Sincerely,
Michell