### PR TITLE
Update ssh.js to add error handling.

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -1,30 +1,43 @@
 var Client = require('ssh2').Client,
   http = require('http');
 
-module.exports = function(opt) {
+module.exports = function (opt) {
   var conn = new Client();
   var agent = new http.Agent();
 
-  agent.createConnection = function(options, fn) {
-    conn.once('ready', function() {
-      conn.exec('docker system dial-stdio', function(err, stream) {
-        if (err) {
-          conn.end();
-          agent.destroy();
-          return;
-        }
+  agent.createConnection = function (options, fn) {
+    try {
+      conn.once('ready', function () {
+        conn.exec('docker system dial-stdio', function (err, stream) {
+          if (err) {
+            handleError(err);
+          }
 
-        fn(null, stream);
-
-        stream.once('close', () => {
-          conn.end();
-          agent.destroy();
+          fn(null, stream);
+          
+          stream.addListener('error', (err) => {
+            handleError(err);
+          });
+          stream.once('close', () => {
+            conn.end();
+            agent.destroy();
+          });
         });
-      });
-    }).connect(opt);
-
-    conn.once('end', () => agent.destroy());
+      }).on('error', (err) => {
+        handleError(err);
+      })
+        .connect(opt);
+      conn.once('end', () => agent.destroy());
+      return agent;
+      
+    } catch (err) {
+      handleError(err);
+    }
   };
 
-  return agent;
+  function handleError(err) {
+    conn.end();
+    agent.destroy();
+    throw err;
+  }
 };


### PR DESCRIPTION
Was running into an issue where I couldn't catch an error if the SSH client timed out. Adding the `.on` catch enabled me to catch it from the parent application. If it needs more changes, please let me know. For now I'm just patching it with `pnpm patch` which I would prefer not to do.