### PR TITLE
Use the per-user Docker socket as the Unix default, if present

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -9,7 +9,8 @@ var querystring = require('querystring'),
   utils = require('./utils'),
   util = require('util'),
   splitca = require('split-ca'),
-  isWin = require('os').type() === 'Windows_NT',
+  os = require('os'),
+  isWin = os.type() === 'Windows_NT',
   stream = require('stream');
 
 var defaultOpts = function () {
@@ -18,12 +19,12 @@ var defaultOpts = function () {
 
   if (!process.env.DOCKER_HOST) {
     // Windows socket path: //./pipe/docker_engine ( Windows 10 )
-    // Linux & Darwin socket path: /var/run/docker.sock
-    opts.socketPath = isWin ? '//./pipe/docker_engine' : '/var/run/docker.sock';
+    // Linux & Darwin socket path is /var/run/docker.sock when running system-wide,
+    // or $HOME/.docker/run/docker.sock in new Docker Desktop installs.
+    opts.socketPath = isWin ? '//./pipe/docker_engine' : findDefaultUnixSocket;
   } else if (process.env.DOCKER_HOST.indexOf('unix://') === 0) {
-    // Strip off unix://, fall back to default of /var/run/docker.sock if
-    // unix:// was passed without a path
-    opts.socketPath = process.env.DOCKER_HOST.substring(7) || '/var/run/docker.sock';
+    // Strip off unix://, fall back to default if unix:// was passed without a path
+    opts.socketPath = process.env.DOCKER_HOST.substring(7) || findDefaultUnixSocket;
   } else if (process.env.DOCKER_HOST.indexOf('npipe://') === 0) {
     // Strip off npipe://, fall back to default of //./pipe/docker_engine if
     // npipe:// was passed without a path
@@ -75,6 +76,16 @@ var defaultOpts = function () {
 
   return opts;
 };
+
+var findDefaultUnixSocket = function () {
+  return new Promise(function (resolve) {
+    var userDockerSocket = path.join(os.homedir(), '.docker', 'run', 'docker.sock');
+    fs.access(userDockerSocket, function (err) {
+      if (err) resolve('/var/run/docker.sock');
+      else resolve(userDockerSocket);
+    })
+  });
+}
 
 
 var Modem = function (options) {
@@ -220,15 +231,21 @@ Modem.prototype.dial = function (options, callback) {
   }
 
   if (this.socketPath) {
-    optionsf.socketPath = this.socketPath;
+    // SocketPath may be a function that can return a promise:
+    var socketPathValue = typeof this.socketPath === 'function'
+      ? this.socketPath() : this.socketPath;
+    Promise.resolve(socketPathValue).then((socketPath) => {
+      optionsf.socketPath = socketPath;
+      this.buildRequest(optionsf, options, data, callback);
+    });
   } else {
     var urlp = url.parse(address);
     optionsf.hostname = urlp.hostname;
     optionsf.port = urlp.port;
     optionsf.path = urlp.path;
-  }
 
-  this.buildRequest(optionsf, options, data, callback);
+    this.buildRequest(optionsf, options, data, callback);
+  }
 };
 
 Modem.prototype.buildRequest = function (options, context, data, callback) {

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -232,9 +232,7 @@ Modem.prototype.dial = function (options, callback) {
 
   if (this.socketPath) {
     // SocketPath may be a function that can return a promise:
-    var socketPathValue = typeof this.socketPath === 'function'
-      ? this.socketPath() : this.socketPath;
-    Promise.resolve(socketPathValue).then((socketPath) => {
+    this.getSocketPath().then((socketPath) => {
       optionsf.socketPath = socketPath;
       this.buildRequest(optionsf, options, data, callback);
     });
@@ -247,6 +245,15 @@ Modem.prototype.dial = function (options, callback) {
     this.buildRequest(optionsf, options, data, callback);
   }
 };
+
+Modem.prototype.getSocketPath = function () {
+  if (!this.socketPath) return;
+
+  var socketPathValue = typeof this.socketPath === 'function'
+    ? this.socketPath() : this.socketPath;
+
+  return Promise.resolve(socketPathValue);
+}
 
 Modem.prototype.buildRequest = function (options, context, data, callback) {
   var self = this;

--- a/test/modem_test.js
+++ b/test/modem_test.js
@@ -7,15 +7,6 @@ var Modem = require('../lib/modem');
 var unixDefaultSocketPaths = ['/var/run/docker.sock', path.join(os.homedir(), '.docker/run/docker.sock')]
 var defaultSocketPaths = os.type() === 'Windows_NT' ? ['//./pipe/docker_engine'] : unixDefaultSocketPaths;
 
-function resolveSocketPath(socketPathField) {
-  if (typeof socketPathField === 'function') {
-    return Promise.resolve(socketPathField());
-  } else {
-    // Return it as a promise, just for consistency
-    return Promise.resolve(socketPathField);
-  }
-}
-
 describe('Modem', function () {
   beforeEach(function () {
     delete process.env.DOCKER_HOST;
@@ -24,7 +15,7 @@ describe('Modem', function () {
   it('should default to default socket path', function () {
     var modem = new Modem();
 
-    return resolveSocketPath(modem.socketPath).then((socketPath) => {
+    return modem.getSocketPath().then((socketPath) => {
       assert.ok(socketPath);
       assert.ok(defaultSocketPaths.includes(socketPath));
     });
@@ -68,7 +59,7 @@ describe('Modem', function () {
     assert.ok(modem.headers);
     assert.strictEqual(modem.headers, customHeaders);
 
-    return resolveSocketPath(modem.socketPath).then((socketPath) => {
+    return modem.getSocketPath().then((socketPath) => {
       assert.ok(socketPath);
       assert.ok(defaultSocketPaths.includes(socketPath));
     });
@@ -86,7 +77,7 @@ describe('Modem', function () {
     process.env.DOCKER_HOST = 'unix://';
 
     var modem = new Modem();
-    return resolveSocketPath(modem.socketPath).then((socketPath) => {
+    return modem.getSocketPath().then((socketPath) => {
       assert.ok(socketPath);
       assert.ok(unixDefaultSocketPaths.includes(socketPath));
     });


### PR DESCRIPTION
This fixes #156. On Mac and Linux, if `$HOME/.docker/run/docker.sock` is present, that will be used by default. If not, the previous `/var/run/docker.sock` will be used instead.

This needs to change a few things, because the check for this is async. To make that work, `socketPath` can now be a function that returns a promise, in which case this will be run and awaited during `dial`.

This shouldn't be a breaking change, but it probably is because (just searching around GitHub) there's quite a few projects that look at `modem.socketPath` directly to see which path was detected. Fortunately it looks like you're already on track for a v4 breaking release anyway, so we can sneak this in there too :smile:.

To make that change easier for downstream users, and to simplify the internals too, this adds a new `getSocketPath` method, which always returns either `undefined` (if no socket path is used - e.g. for remote hosts & SSH) or a promise that should resolve to the path.

Anybody who wants the path can use `socketPath = await modem.getSocketPath()` and they'll always get either a string or undefined.

Sound reasonable?

There is another way to implement this, by changing the API completely to replace the simple `new Modem` constructor with an async `buildModem` method that returns a promise. In that case, we could calculate the socketPath during the method, and then everything after that resolved would just be synchronous. That's a bit cleaner in some ways (no new async steps during dial, socketPath is always just a string or undefined) but it's a bigger breaking change so I've avoided it here. Let me know if you'd prefer that.