### PR TITLE
Update ssh.js

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -28,7 +28,6 @@ module.exports = function (opt) {
       })
         .connect(opt);
       conn.once('end', () => agent.destroy());
-      return agent;
       
     } catch (err) {
       handleError(err);
@@ -40,4 +39,6 @@ module.exports = function (opt) {
     agent.destroy();
     throw err;
   }
+
+  return agent;
 };


### PR DESCRIPTION
pr #154 definitely broke ssh functionality for me. Not sure why the `return agent` statement was moved up into `agent.createConnection` scope, but by doing so it results in any [call](https://github.com/apocas/docker-modem/blob/17faa294781585726d241cecb35c4bf0edbe885f/lib/modem.js#L267-L271) to the ssh module to return `undefined` instead of an ssh agent. Which makes sense as this function never returns anything anymore, instead `createConnection` function returns the agent but that doesn't make sense based on how it is used.