### PR TITLE
Return raw buffer instead of string

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -340,7 +340,7 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
 
         debug('Received: %s', result);
 
-        var json = utils.parseJSON(result) || result;
+        var json = utils.parseJSON(result) || buffer;
         if (finished === false) {
           finished = true;
           self.buildPayload(null, context.isStream, context.statusCodes, false, req, res, json, callback);


### PR DESCRIPTION
As discussed here: https://github.com/apocas/dockerode/issues/751. It looks like this was an unintentional change made during the "revert" in https://github.com/apocas/docker-modem/commit/8e054177ded397b6166159fd723b0e45445d3ae7.