### PR TITLE
fix: check for error field when looking for cause of error

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -382,7 +382,7 @@ Modem.prototype.buildPayload = function (err, isStream, statusCodes, openStdin, 
       var msg = new Error(
         '(HTTP code ' + res.statusCode + ') ' +
         (statusCodes[res.statusCode] || 'unexpected') + ' - ' +
-        (cause.message || cause) + ' '
+        (cause.message || cause.error || cause) + ' '
       );
       msg.reason = statusCodes[res.statusCode];
       msg.statusCode = res.statusCode;


### PR DESCRIPTION
Fix #171 