### PR TITLE
Small changes for BuildKit support

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -302,6 +302,9 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
     req.on('upgrade', function (res, sock, head) {
       if (finished === false) {
         finished = true;
+        if (head.length > 0) {
+          sock.unshift(head);
+        }
         return callback(null, sock);
       }
     });

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -227,7 +227,7 @@ Modem.prototype.dial = function (options, callback) {
 
   if (options.hijack) {
     optionsf.headers.Connection = 'Upgrade';
-    optionsf.headers.Upgrade = 'tcp';
+    optionsf.headers.Upgrade ??= 'tcp';
   }
 
   if (this.socketPath) {
@@ -366,7 +366,7 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
     data.pipe(req);
   }
 
-  if (!context.hijack && !context.openStdin && (typeof data === 'string' || data === undefined || Buffer.isBuffer(data))) {
+  if (!context.openStdin && (typeof data === 'string' || data === undefined || Buffer.isBuffer(data))) {
     req.end();
   }
 };

--- a/lib/modem.js
+++ b/lib/modem.js
@@ -227,7 +227,7 @@ Modem.prototype.dial = function (options, callback) {
 
   if (options.hijack) {
     optionsf.headers.Connection = 'Upgrade';
-    optionsf.headers.Upgrade ??= 'tcp';
+    optionsf.headers.Upgrade = optionsf.headers.Upgrade ?? 'tcp';
   }
 
   if (this.socketPath) {


### PR DESCRIPTION
I would like to tackle BuildKit support in dockerode. That required some small changes in docker-modem, because the connection needs to be hijacked to create a session.

The first change (preverse `Upgrade` header) should be safe.

I am uncertain about the second change (ending the request in hijack mode). The tests still pass, but could this have other unintended side effects? To open a session over the docker api, this is needed - otherwise the `upgrade` event is never emittet. But we could allow this to be configured some other way as well.