### PR TITLE
Bugfix: Fix for uncatchable dns error

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -140,6 +140,11 @@ Modem.prototype.dial = function (options, callback) {
     delete opts.abortSignal;
   }
 
+  // Prevent uncatchable dns error
+  if (options.path.startsWith('/')) {
+    throw new Error('Path cannot start with a backslash');
+  }
+
   if (this.version) {
     options.path = '/' + this.version + options.path;
   }


### PR DESCRIPTION
see #176 

Stops `options.path` being passed in with a leading backslash, which causes uncatchable DNS errors.