### PR TITLE
fix: fix memory leak if `timeout` is set

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -283,17 +283,15 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
   if (self.connectionTimeout) {
     connectionTimeoutTimer = setTimeout(function () {
       debug('Connection Timeout of %s ms exceeded', self.connectionTimeout);
-      req.abort();
+      req.destroy();
     }, self.connectionTimeout);
   }
 
   if (self.timeout) {
-    req.on('socket', function (socket) {
-      socket.setTimeout(self.timeout);
-      socket.on('timeout', function () {
-        debug('Timeout of %s ms exceeded', self.timeout);
-        req.abort();
-      });
+    req.setTimeout(self.timeout);
+    req.on('timeout', function () {
+      debug('Timeout of %s ms exceeded', self.timeout);
+      req.destroy();
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-modem",
-  "version": "5.0.2",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-modem",
-      "version": "5.0.2",
+      "version": "5.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docker-modem",
   "description": "Docker remote API network layer module.",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "author": "Pedro Dias <petermdias@gmail.com>",
   "maintainers": [
     "apocas <petermdias@gmail.com>"


### PR DESCRIPTION
## Issue

Currently, if `timeout` option is provided, one more event listener is added to the underlying socket _on each request_. This causes the number of `timeout` event listeners for each socket to grow over time until the socket is destroyed. In my tests, the number of event listeners for single socket can exceed 400.

![image](https://github.com/codefresh-io/docker-modem/assets/32432324/256db376-69cc-4311-af2c-9a73862907f9)

Moreover, it closures Request object within timeout handler preventing it from being garbage collected far beyond its lifecycle.

![image](https://github.com/codefresh-io/docker-modem/assets/32432324/6a937d2b-1437-428d-ad34-0afb40ebe36e)

## Resolution

This PR changes timeout implementation, by adding `timeout` event listener directly to the Request object instead of the Socket. Considering that `request.setTimeout` implicitly calls an appropriate `socket.setTimeout()` ([docs](https://nodejs.org/docs/latest-v20.x/api/net.html#socketsettimeouttimeout-callback)); and `timeout` event is propagated from the underlying socket to the request itself ([docs](https://nodejs.org/docs/latest-v20.x/api/http.html#event-timeout)); the original behavior will remain unchanged.

At the same time this will prevent Socket event listeners count from growing and will also allow garbage collecting Request objects.

![image](https://github.com/codefresh-io/docker-modem/assets/32432324/cb82e1d3-b017-4ddc-abb9-c4dd4850b9d3)
![image](https://github.com/codefresh-io/docker-modem/assets/32432324/b96b1f22-67c1-451f-8cfe-8b9cbb2a107f)

Also, this PR replaces deprecated `request.abort()` with `request.destroy()`.

