### PR TITLE
Fix handling of SSH network errors

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -10,13 +10,13 @@ module.exports = function (opt) {
       conn.once('ready', function () {
         conn.exec('docker system dial-stdio', function (err, stream) {
           if (err) {
-            handleError(err);
+            handleError(err , fn);
           }
 
           fn(null, stream);
           
           stream.addListener('error', (err) => {
-            handleError(err);
+            handleError(err, fn);
           });
           stream.once('close', () => {
             conn.end();
@@ -24,7 +24,7 @@ module.exports = function (opt) {
           });
         });
       }).on('error', (err) => {
-        handleError(err);
+        handleError(err, fn);
       })
         .connect(opt);
       conn.once('end', () => agent.destroy());
@@ -34,10 +34,14 @@ module.exports = function (opt) {
     }
   };
 
-  function handleError(err) {
+  function handleError(err, cb) {
     conn.end();
     agent.destroy();
-    throw err;
+    if (cb) {
+      cb(err);
+    } else {
+      throw err;
+    }
   }
 
   return agent;


### PR DESCRIPTION
This fixes handling ssh connection errors by using error callback instead of throwing an exception when appropriate.

This resolves issue apocas/dockerode#764 and replaced pull request #163