### PR TITLE
Fix missing callback in buildRequest.

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -273,7 +273,13 @@ Modem.prototype.buildRequest = function (options, context, data, callback) {
     protocol: 'http:',
   }) : options;
 
-  var req = http[self.protocol === 'ssh' ? 'http' : self.protocol].request(opts, function () { });
+  var req = null;
+  try {
+    req = http[self.protocol === 'ssh' ? 'http' : self.protocol].request(opts, function () { });
+  } catch (e) {
+    callback(e);
+    return;
+  }
 
   debug('Sending: %s', util.inspect(options, {
     showHidden: true,


### PR DESCRIPTION
Add a missing callback in the case where node:http.request() throws an exception (e.g. if the caller has passed an unescaped Docker container name).