### PR TITLE
fix(Modem#dial): prefer provided Content-Type

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -203,14 +203,14 @@ Modem.prototype.dial = function (options, callback) {
     } else {
       data = options.file;
     }
-    optionsf.headers['Content-Type'] = 'application/tar';
+    optionsf.headers['Content-Type'] = options?.headers?.['Content-Type'] ?? 'application/tar';
   } else if (opts && options.method === 'POST') {
     data = JSON.stringify(opts._body || opts);
     if (options.allowEmpty) {
-      optionsf.headers['Content-Type'] = 'application/json';
+      optionsf.headers['Content-Type'] = options?.headers?.['Content-Type'] ?? 'application/json';
     } else {
       if (data !== '{}' && data !== '""') {
-        optionsf.headers['Content-Type'] = 'application/json';
+        optionsf.headers['Content-Type'] = options?.headers?.['Content-Type'] ?? 'application/json';
       } else {
         data = undefined;
       }


### PR DESCRIPTION
## Description

When the user is providing headers, the default implementation where overriding it. The user value should be preferred if defined  or use current default for backward compatibility.

## Related issues

Fixes https://github.com/apocas/docker-modem/issues/188