### PR TITLE
chore(workflows): adding release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm publish


### PR DESCRIPTION
## Description

Following guidelines in https://docs.npmjs.com/trusted-publishers we need to specify add a workflow to trust the origin of the release process.

Once configured, the maintainer will be able to push tags to the repository, and it will automatically published to npm

## Related issues

https://github.com/apocas/docker-modem/issues/192