### PR TITLE
fix(modem): validate stream type in demuxStream and flush on end

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -438,31 +438,55 @@ Modem.prototype.buildPayload = function (err, isStream, statusCodes, openStdin, 
 };
 
 Modem.prototype.demuxStream = function (streama, stdout, stderr) {
-  var nextDataType = null;
-  var nextDataLength = null;
+  var pendingStreamType = null;
+  var pendingDataLength = null;
   var buffer = Buffer.from('');
+  
   function processData(data) {
     if (data) {
       buffer = Buffer.concat([buffer, data]);
     }
-    if (!nextDataType) {
+    if (pendingStreamType === null) {
       if (buffer.length >= 8) {
         var header = bufferSlice(8);
-        nextDataType = header.readUInt8(0);
-        nextDataLength = header.readUInt32BE(4);
+        var streamType = header.readUInt8(0);
+        var dataLength = header.readUInt32BE(4);
+
+        // Validate stream type per Docker multiplex protocol:
+        // 0 = stdin, 1 = stdout, 2 = stderr
+        if (streamType !== 0 && streamType !== 1 && streamType !== 2) {
+          // Invalid header — stream is likely not multiplexed (e.g. TTY mode)
+          // or has become misaligned. Write the entire buffer as stdout
+          // and stop trying to demux.
+          var remaining = Buffer.concat([header, buffer]);
+          stdout.write(remaining);
+          buffer = Buffer.from('');
+          pendingStreamType = null;
+          pendingDataLength = null;
+          // Switch to raw passthrough for the rest of the stream
+          streama.removeListener('data', processData);
+          streama.on('data', function(chunk) {
+            stdout.write(chunk);
+          });
+          return;
+        }
+
+        pendingStreamType = streamType;
+        pendingDataLength = dataLength;
         // It's possible we got a "data" that contains multiple messages
         // Process the next one
         processData();
       }
     } else {
-      if (buffer.length >= nextDataLength) {
-        var content = bufferSlice(nextDataLength);
-        if (nextDataType === 1) {
+      if (buffer.length >= pendingDataLength) {
+        var content = bufferSlice(pendingDataLength);
+        if (pendingStreamType === 1) {
           stdout.write(content);
         } else {
           stderr.write(content);
         }
-        nextDataType = null;
+        pendingStreamType = null;
+        pendingDataLength = null;
         // It's possible we got a "data" that contains multiple messages
         // Process the next one
         processData();


### PR DESCRIPTION
## Problem

`demuxStream` blindly trusts the first byte of each 8-byte header as a valid Docker multiplex stream type. When the stream is not actually multiplexed (e.g. TTY mode) or framing becomes misaligned, a garbage type byte causes a garbage frame length, which misaligns every subsequent frame. The result is corrupted leading bytes in the demuxed output.

This forces downstream consumers to add workarounds like:
```js
// fix dockerode bug returning invalid leading characters
JSON.parse(json.substring(json.indexOf('{')))
```

See for example:

* [nextcloud-libraries/nextcloud-e2e-test-server@780218412e — lib/docker.ts L259-262](https://github.com/nextcloud-libraries/nextcloud-e2e-test-server/blob/780218412e57bd774393a409e65f9d8b3ded7f5f/lib/docker.ts#L259-L262)

Related (may fix) issues:

* #159 — Troubles with demuxStream called from docker.run
* #129 — Add the ability to demux a buffer

Changes:

* Validate the stream type byte (must be 0, 1, or 2) after reading each header. On an invalid value, flush all buffered data to stdout and switch to raw passthrough for the rest of the stream.
* Listen for the source stream's end event and flush any remaining buffered bytes to stdout instead of silently dropping them.